### PR TITLE
chore: Fix token order in modal

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/AddLiquidityModal.tsx
+++ b/lib/modules/pool/actions/add-liquidity/AddLiquidityModal.tsx
@@ -142,7 +142,7 @@ export function AddLiquidityModal({
                     isSameAddress(amountIn.tokenAddress, token?.address)
                   ) as HumanAmountIn
 
-                  return <TokenAmountRow key={token?.address} {...amountIn} />
+                  return <TokenAmountRow key={token.address} {...amountIn} />
                 })}
               </VStack>
             </Card>


### PR DESCRIPTION
# Description

It's a bit verbose, but this ensures the tokens are ordered the same in the modal as in the form.