### PR TITLE
fix: Fixes some issues with the user address pool filter

### DIFF
--- a/app/(app)/pools/page.tsx
+++ b/app/(app)/pools/page.tsx
@@ -17,6 +17,7 @@ interface Props {
     poolTypes?: string
     networks?: string
     textSearch?: string
+    userAddress?: string
   }
 }
 
@@ -39,6 +40,7 @@ export default async function Pools({ searchParams }: Props) {
     where: {
       poolTypeIn: mappedPoolTypes,
       chainIn: networks.length > 0 ? networks : PROJECT_CONFIG.supportedNetworks,
+      userAddress: poolListQueryStateParsers.userAddress.parseServerSide(searchParams.userAddress),
     },
     textSearch: poolListQueryStateParsers.textSearch.parseServerSide(searchParams.textSearch),
   }

--- a/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -126,6 +126,8 @@ const FilterButton = forwardRef<ButtonProps, 'button'>((props, ref) => {
 })
 
 export function PoolListFilters() {
+  const { isConnected } = useUserAccount()
+
   return (
     <VStack align="flex-start" w="full">
       <HStack w="full">
@@ -139,11 +141,16 @@ export function PoolListFilters() {
             <PopoverCloseButton />
             <PopoverBody p="md">
               <VStack align="start">
-                <Heading as="h3" size="sm" mb="1.5">
-                  My Liquidity
-                </Heading>
-                <UserPoolFilter />
-                <Divider />
+                {isConnected && (
+                  <>
+                    <Heading as="h3" size="sm" mb="1.5">
+                      My Liquidity
+                    </Heading>
+                    <UserPoolFilter />
+                    <Divider />
+                  </>
+                )}
+
                 <Heading as="h3" size="sm" mb="1.5">
                   Pool types
                 </Heading>

--- a/lib/modules/pool/PoolList/usePoolOrderByState.ts
+++ b/lib/modules/pool/PoolList/usePoolOrderByState.ts
@@ -2,17 +2,15 @@ import { GqlPoolOrderBy } from '@/lib/shared/services/api/generated/graphql'
 import { useState, useEffect } from 'react'
 import { usePoolListQueryState } from './usePoolListQueryState'
 
+const defaultOrderBy = [GqlPoolOrderBy.TotalLiquidity, GqlPoolOrderBy.Volume24h, GqlPoolOrderBy.Apr]
+
 export function usePoolOrderByState() {
   const { sorting, setSorting, userAddress } = usePoolListQueryState()
-  const [orderBy, setOrderBy] = useState([
-    GqlPoolOrderBy.TotalLiquidity,
-    GqlPoolOrderBy.Volume24h,
-    GqlPoolOrderBy.Apr,
-  ])
+  const [orderBy, setOrderBy] = useState(defaultOrderBy)
 
   useEffect(() => {
     if (userAddress) {
-      setOrderBy([GqlPoolOrderBy.UserbalanceUsd, ...orderBy])
+      setOrderBy([GqlPoolOrderBy.UserbalanceUsd, ...defaultOrderBy])
       setSorting([{ id: GqlPoolOrderBy.UserbalanceUsd, desc: true }])
     } else {
       setOrderBy(orderBy.filter(item => item !== GqlPoolOrderBy.UserbalanceUsd))


### PR DESCRIPTION
# Description

- The RSC query needed the userAddress param in the attributes to prevent a second fetch on page load.
- Hide the filter option if no wallet is connected.
- If the user changes address in wallet and has previously applied the 'My liquidity' filter we should swap out the address for the new one.
- There was a bug in the `usePoolOrderByState` that caused additional table columns to be added everytime you connected a new address.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test filtering by userAddress, switch accounts, disconnect and reconnect.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
