### PR TITLE
Add boosted/stable pool weight chart (3 token) + better halos

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolStats.tsx
+++ b/lib/modules/pool/PoolDetail/PoolStats.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { Box, Card, Center, Grid, Heading, Skeleton, VStack } from '@chakra-ui/react'
+import { Box, Card, Grid, Heading, Skeleton, VStack } from '@chakra-ui/react'
 import PoolBadges from './PoolBadges'
 import { usePool } from '../usePool'
 import { getAprLabel } from '../pool.utils'
 import { useCurrency } from '@/lib/shared/hooks/useCurrency'
-import BoostedPoolWeightChart from './PoolWeightCharts/BoostedPoolWeightChart'
 import PoolWeightChart from './PoolWeightCharts/PoolWeightChart'
 import { GqlPoolAprValue } from '@/lib/shared/services/api/generated/graphql'
 

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/BoostedPoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/BoostedPoolWeightChart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { Box, HStack, VStack, Text } from '@chakra-ui/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
@@ -5,8 +6,7 @@ import EChartsReactCore from 'echarts-for-react/lib/core'
 import * as echarts from 'echarts/core'
 import { usePool } from '../../usePool'
 import { motion } from 'framer-motion'
-import Image from 'next/image'
-import ChainLogoHalo from './ChainLogoHalo'
+import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
 
 const colors = [
   {
@@ -53,7 +53,7 @@ export default function BoostedPoolWeightChart() {
   const chartOption = useMemo(() => {
     return {
       tooltip: {
-        show: false
+        show: false,
       },
       legend: {
         show: false,
@@ -98,7 +98,7 @@ export default function BoostedPoolWeightChart() {
   }, [])
 
   return (
-    <VStack spacing='4'>
+    <VStack spacing="4">
       <svg
         style={{ visibility: 'hidden', position: 'absolute' }}
         width="0"
@@ -135,9 +135,8 @@ export default function BoostedPoolWeightChart() {
           justifyContent="center"
           alignItems="center"
           initial={{ opacity: 0 }}
-          animate={{ opacity: isChartLoaded ? 1 : 0, transition: { delay: 0.1 } }}
         >
-          <ChainLogoHalo chain={chain} isChartLoaded={isChartLoaded} />
+          <PoolWeightChartChainIcon chain={chain} isChartLoaded={isChartLoaded} />
         </Box>
         <Box width="full" height="full" clipPath="polygon(50% 0, 100% 100%, 0 100%)">
           <ReactECharts option={chartOption} onEvents={{}} ref={eChartsRef} />
@@ -160,6 +159,6 @@ export default function BoostedPoolWeightChart() {
           )
         })}
       </HStack>
-    </VStack >
+    </VStack>
   )
 }

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
@@ -8,7 +8,7 @@ import BoostedPoolWeightChart from './BoostedPoolWeightChart'
 export default function PoolWeightChart() {
   const { pool } = usePool()
 
-  if (isBoosted(pool) || isStable(pool.type) && pool.tokens.length === 3) {
+  if (isBoosted(pool) || (isStable(pool.type) && pool.tokens.length === 3)) {
     return <BoostedPoolWeightChart />
   }
   if (pool.type === 'WEIGHTED') {

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartChainIcon.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartChainIcon.tsx
@@ -1,17 +1,15 @@
-import { GqlChain } from "@/lib/shared/services/api/generated/graphql"
-import { Box } from "@chakra-ui/react"
-import { motion } from "framer-motion"
+import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
+import { Box } from '@chakra-ui/react'
+import { motion } from 'framer-motion'
 import Image from 'next/image'
 
 type Props = {
   chain: GqlChain
-  isChartLoaded: boolean;
+  isChartLoaded: boolean
 }
-export default function ChainLogoHalo({ chain, isChartLoaded }: Props) {
+export default function PoolWeightChartChainIcon({ chain, isChartLoaded }: Props) {
   return (
-    <Box
-      position="relative"
-    >
+    <Box position="relative">
       <Box zIndex={4}>
         <Image
           src={`/images/chains/${chain}.svg`}
@@ -23,15 +21,15 @@ export default function ChainLogoHalo({ chain, isChartLoaded }: Props) {
 
       <Box
         as={motion.div}
-        background='white'
-        borderRadius='full'
-        position='absolute'
-        top='0'
-        bottom='0'
-        left='0'
-        right='0'
-        width='45px'
-        height='45px'
+        background="white"
+        borderRadius="full"
+        position="absolute"
+        top="0"
+        bottom="0"
+        left="0"
+        right="0"
+        width="45px"
+        height="45px"
         transform="scale(1.75)"
         initial={{ opacity: 0 }}
         animate={{ opacity: isChartLoaded ? 0.2 : 0, transition: { delay: 0.2 } }}
@@ -39,15 +37,15 @@ export default function ChainLogoHalo({ chain, isChartLoaded }: Props) {
       />
       <Box
         as={motion.div}
-        background='white'
-        borderRadius='full'
-        position='absolute'
-        top='0'
-        bottom='0'
-        left='0'
-        right='0'
-        width='45px'
-        height='45px'
+        background="white"
+        borderRadius="full"
+        position="absolute"
+        top="0"
+        bottom="0"
+        left="0"
+        right="0"
+        width="45px"
+        height="45px"
         transform="scale(2.15)"
         initial={{ opacity: 0 }}
         animate={{ opacity: isChartLoaded ? 0.1 : 0, transition: { delay: 0.4 } }}

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/WeightedPoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/WeightedPoolWeightChart.tsx
@@ -2,11 +2,10 @@ import { Box, HStack, VStack, Text } from '@chakra-ui/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import EChartsReactCore from 'echarts-for-react/lib/core'
-import Image from 'next/image'
 import { usePool } from '../../usePool'
 import * as echarts from 'echarts/core'
 import { motion } from 'framer-motion'
-import ChainLogoHalo from './ChainLogoHalo'
+import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
 
 const colors = [
   {
@@ -117,7 +116,7 @@ export default function WeightedPoolWeightChart() {
           initial={{ opacity: 0 }}
           animate={{ opacity: isChartLoaded ? 1 : 0, transition: { delay: 0.1 } }}
         >
-          <ChainLogoHalo chain={chain} isChartLoaded={isChartLoaded} />
+          <PoolWeightChartChainIcon chain={chain} isChartLoaded={isChartLoaded} />
         </Box>
         <Box width="full" height="full">
           <ReactECharts option={chartOption} onEvents={{}} ref={eChartsRef} />

--- a/lib/modules/pool/PoolList/usePoolList.tsx
+++ b/lib/modules/pool/PoolList/usePoolList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 'use client'
 
 import { createContext, ReactNode, useEffect } from 'react'

--- a/lib/modules/pool/PoolList/usePoolOrderByState.ts
+++ b/lib/modules/pool/PoolList/usePoolOrderByState.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { GqlPoolOrderBy } from '@/lib/shared/services/api/generated/graphql'
 import { useState, useEffect } from 'react'
 import { usePoolListQueryState } from './usePoolListQueryState'

--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -49,7 +49,6 @@ export function RemoveLiquidityForm() {
     setSingleTokenType,
     setHumanBptInPercent,
     humanBptInPercent,
-    totalUsdFromBprPrice,
     totalUsdValue,
     priceImpact,
     isPriceImpactLoading,


### PR DESCRIPTION
# Description

Adds the triangle chart from designs. This is for boosted pools. Unfortunately it only looks good with a distribution of 3 tokens so I've limited its display criteria to that. I am also showing this weight chart for stable pools as well because I couldn't find a boosted pool.

Also introduces a change which adds better halos to the chain logo in the centre of the chart, since it uses transforms it will also we perfectly haloing the original image.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Open up a stable pool with 3 tokens.

## Visual context

<img width="1314" alt="image" src="https://github.com/balancer/frontend-v3/assets/40786269/e751fa21-5328-4a85-9572-623cda475905">


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
