### PR TITLE
chore: Simplify handler fn names

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/handlers/AddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/AddLiquidity.handler.ts
@@ -18,12 +18,12 @@ import { BuildAddLiquidityInput, QueryAddLiquidityOutput } from '../add-liquidit
 export interface AddLiquidityHandler {
   // Query the expected output of adding liquidity and store it inside the handler instance
   // Also returns bptOut to be used by the UI
-  queryAddLiquidity(humanAmountsIn: HumanAmountIn[]): Promise<QueryAddLiquidityOutput>
+  simulate(humanAmountsIn: HumanAmountIn[]): Promise<QueryAddLiquidityOutput>
   // Calculate the price impact of adding liquidity
-  calculatePriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number>
+  getPriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number>
   /*
     Build tx callData payload for adding liquidity
     It is responsibility of the UI to avoid calling buildAddLiquidityCallData before the last queryAddLiquidity was finished
   */
-  buildAddLiquidityCallData(inputs: BuildAddLiquidityInput): Promise<TransactionConfig>
+  buildCallData(inputs: BuildAddLiquidityInput): Promise<TransactionConfig>
 }

--- a/lib/modules/pool/actions/add-liquidity/handlers/TwammAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/TwammAddLiquidity.handler.ts
@@ -17,7 +17,7 @@ export class TwammAddLiquidityHandler implements AddLiquidityHandler {
   constructor(private chainId: SupportedChainId) {}
 
   // TODO: This is a non-sense example implementation
-  public async queryAddLiquidity(humanAmountsIn: HumanAmountIn[]) {
+  public async simulate(humanAmountsIn: HumanAmountIn[]) {
     this.humanAmountsIn = humanAmountsIn
     const tokenAmount = TokenAmount.fromHumanAmount(
       {} as unknown as Token,
@@ -28,14 +28,12 @@ export class TwammAddLiquidityHandler implements AddLiquidityHandler {
   }
 
   // TODO: This is a non-sense example implementation
-  public async calculatePriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number> {
+  public async getPriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number> {
     return Number(humanAmountsIn[0].humanAmount)
   }
 
   // TODO: This is a non-sense example implementation
-  public async buildAddLiquidityCallData({
-    account,
-  }: BuildAddLiquidityInput): Promise<TransactionConfig> {
+  public async buildCallData({ account }: BuildAddLiquidityInput): Promise<TransactionConfig> {
     if (!this.humanAmountsIn) {
       throw new Error(
         `Missing humanAmountsIn.

--- a/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.integration.spec.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.integration.spec.ts
@@ -24,7 +24,7 @@ describe('When adding unbalanced liquidity for a weighted  pool', () => {
       { humanAmount: '1', tokenAddress: wjAuraAddress },
     ]
 
-    const priceImpact = await handler.calculatePriceImpact(humanAmountsIn)
+    const priceImpact = await handler.getPriceImpact(humanAmountsIn)
     expect(priceImpact).toBeGreaterThan(0.002)
   })
 
@@ -36,7 +36,7 @@ describe('When adding unbalanced liquidity for a weighted  pool', () => {
       { humanAmount: '', tokenAddress: balAddress },
     ]
 
-    const priceImpact = await handler.calculatePriceImpact(humanAmountsIn)
+    const priceImpact = await handler.getPriceImpact(humanAmountsIn)
 
     expect(priceImpact).toEqual(0)
   })
@@ -49,7 +49,7 @@ describe('When adding unbalanced liquidity for a weighted  pool', () => {
 
     const handler = selectUnbalancedHandler()
 
-    const result = await handler.queryAddLiquidity(humanAmountsIn)
+    const result = await handler.simulate(humanAmountsIn)
 
     expect(result.bptOut.amount).toBeGreaterThan(300000000000000000000n)
   })
@@ -63,9 +63,9 @@ describe('When adding unbalanced liquidity for a weighted  pool', () => {
     const handler = selectUnbalancedHandler()
 
     // Store query response in handler instance
-    const queryOutput = await handler.queryAddLiquidity(humanAmountsIn)
+    const queryOutput = await handler.simulate(humanAmountsIn)
 
-    const result = await handler.buildAddLiquidityCallData({
+    const result = await handler.buildCallData({
       humanAmountsIn,
       account: defaultTestUserAccount,
       slippagePercent: '0.2',
@@ -92,7 +92,7 @@ describe('When adding unbalanced liquidity for a stable pool', () => {
       }
     })
 
-    const priceImpact = await handler.calculatePriceImpact(humanAmountsIn)
+    const priceImpact = await handler.getPriceImpact(humanAmountsIn)
     expect(priceImpact).toBeGreaterThan(0.001)
   })
 })

--- a/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
@@ -29,9 +29,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
     this.helpers = new LiquidityActionHelpers(pool)
   }
 
-  public async queryAddLiquidity(
-    humanAmountsIn: HumanAmountIn[]
-  ): Promise<SdkQueryAddLiquidityOutput> {
+  public async simulate(humanAmountsIn: HumanAmountIn[]): Promise<SdkQueryAddLiquidityOutput> {
     const addLiquidity = new AddLiquidity()
     const addLiquidityInput = this.constructSdkInput(humanAmountsIn)
 
@@ -40,7 +38,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
     return { bptOut: sdkQueryOutput.bptOut, sdkQueryOutput }
   }
 
-  public async calculatePriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number> {
+  public async getPriceImpact(humanAmountsIn: HumanAmountIn[]): Promise<number> {
     if (areEmptyAmounts(humanAmountsIn)) {
       // Avoid price impact calculation when there are no amounts in
       return 0
@@ -56,7 +54,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
     return priceImpactABA.decimal
   }
 
-  public async buildAddLiquidityCallData({
+  public async buildCallData({
     account,
     slippagePercent,
     queryOutput,

--- a/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityBuildCallDataQuery.ts
+++ b/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityBuildCallDataQuery.ts
@@ -47,7 +47,7 @@ export function useAddLiquidityBuildCallDataQuery({
           2. When we refetch after countdown timeout we explicitly wait for the preview query to finish
       */
     const queryOutput = ensureLastQueryResponse('Add liquidity query', simulationQuery.data)
-    const response = await handler.buildAddLiquidityCallData({
+    const response = await handler.buildCallData({
       account: userAddress,
       humanAmountsIn,
       slippagePercent: slippage,

--- a/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
+++ b/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
@@ -30,7 +30,7 @@ export function useAddLiquidityPriceImpactQuery(
     humanAmountsIn: debouncedHumanAmountsIn,
   })
 
-  const queryFn = async () => handler.calculatePriceImpact(humanAmountsIn)
+  const queryFn = async () => handler.getPriceImpact(humanAmountsIn)
 
   const queryOpts = {
     enabled: enabled && isConnected && !areEmptyAmounts(humanAmountsIn),

--- a/lib/modules/pool/actions/add-liquidity/queries/useAddLiquiditySimulationQuery.ts
+++ b/lib/modules/pool/actions/add-liquidity/queries/useAddLiquiditySimulationQuery.ts
@@ -32,7 +32,7 @@ export function useAddLiquiditySimulationQuery(
     humanAmountsIn: debouncedHumanAmountsIn,
   })
 
-  const queryFn = async () => handler.queryAddLiquidity(humanAmountsIn)
+  const queryFn = async () => handler.simulate(humanAmountsIn)
 
   const queryOpts = {
     enabled: enabled && isConnected && hasValidHumanAmounts(debouncedHumanAmountsIn),

--- a/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.integration.spec.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.integration.spec.ts
@@ -29,7 +29,7 @@ describe('When proportionally removing liquidity for a weighted pool', () => {
   test('returns ZERO price impact', async () => {
     const handler = selectProportionalHandler(poolMock)
 
-    const result = await handler.queryRemoveLiquidity(defaultQueryInput)
+    const result = await handler.simulate(defaultQueryInput)
 
     const [balTokenAmountOut, wEthTokenAmountOut] = result.amountsOut
 
@@ -42,7 +42,7 @@ describe('When proportionally removing liquidity for a weighted pool', () => {
   test('queries amounts out', async () => {
     const handler = selectProportionalHandler(poolMock)
 
-    const result = await handler.queryRemoveLiquidity(defaultQueryInput)
+    const result = await handler.simulate(defaultQueryInput)
 
     const [balTokenAmountOut, wEthTokenAmountOut] = result.amountsOut
 
@@ -56,9 +56,9 @@ describe('When proportionally removing liquidity for a weighted pool', () => {
   test('builds Tx Config', async () => {
     const handler = selectProportionalHandler(poolMock)
 
-    const queryOutput = await handler.queryRemoveLiquidity(defaultQueryInput)
+    const queryOutput = await handler.simulate(defaultQueryInput)
 
-    const result = await handler.buildRemoveLiquidityCallData({
+    const result = await handler.buildCallData({
       ...defaultBuildInput,
       queryOutput,
     })
@@ -74,9 +74,9 @@ describe('When removing liquidity from a stable pool', () => {
 
     const handler = selectProportionalHandler(pool)
 
-    const queryOutput = await handler.queryRemoveLiquidity(defaultQueryInput)
+    const queryOutput = await handler.simulate(defaultQueryInput)
 
-    const result = await handler.buildRemoveLiquidityCallData({ ...defaultBuildInput, queryOutput })
+    const result = await handler.buildCallData({ ...defaultBuildInput, queryOutput })
     expect(result.account).toBe(defaultTestUserAccount)
   })
 })

--- a/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
@@ -26,7 +26,7 @@ export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandle
     this.helpers = new LiquidityActionHelpers(pool)
   }
 
-  public async queryRemoveLiquidity({
+  public async simulate({
     humanBptIn: bptIn,
   }: QueryRemoveLiquidityInput): Promise<SdkQueryRemoveLiquidityOutput> {
     const removeLiquidity = new RemoveLiquidity()
@@ -40,12 +40,12 @@ export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandle
     return { amountsOut: sdkQueryOutput.amountsOut, sdkQueryOutput }
   }
 
-  public async calculatePriceImpact(): Promise<number> {
+  public async getPriceImpact(): Promise<number> {
     // proportional remove liquidity does not have price impact
     return 0
   }
 
-  public async buildRemoveLiquidityCallData({
+  public async buildCallData({
     account,
     slippagePercent,
     queryOutput,

--- a/lib/modules/pool/actions/remove-liquidity/handlers/RemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/RemoveLiquidity.handler.ts
@@ -12,12 +12,12 @@ import {
  */
 export interface RemoveLiquidityHandler {
   // Query the SDK for the expected output of removing liquidity
-  queryRemoveLiquidity(inputs: QueryRemoveLiquidityInput): Promise<QueryRemoveLiquidityOutput>
+  simulate(inputs: QueryRemoveLiquidityInput): Promise<QueryRemoveLiquidityOutput>
   // Calculate the price impact of removing liquidity
-  calculatePriceImpact(inputs: QueryRemoveLiquidityInput): Promise<number>
+  getPriceImpact(inputs: QueryRemoveLiquidityInput): Promise<number>
   /*
     Build tx callData payload for removing liquidity
     It is responsibility of the UI to avoid calling buildRemoveLiquidityCallData before the last queryRemoveLiquidity was finished
   */
-  buildRemoveLiquidityCallData(inputs: BuildRemoveLiquidityInput): Promise<TransactionConfig>
+  buildCallData(inputs: BuildRemoveLiquidityInput): Promise<TransactionConfig>
 }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.integration.spec.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.integration.spec.ts
@@ -27,7 +27,7 @@ describe('When removing unbalanced liquidity for a weighted pool', () => {
   test('queries amounts out', async () => {
     const handler = selectSingleTokenHandler(poolMock)
 
-    const result = await handler.queryRemoveLiquidity(defaultQueryInput)
+    const result = await handler.simulate(defaultQueryInput)
 
     const [balTokenAmountOut, wEthTokenAmountOut] = result.amountsOut
 
@@ -46,9 +46,9 @@ describe('When removing unbalanced liquidity for a weighted pool', () => {
       tokenOut: balAddress,
     }
 
-    const queryOutput = await handler.queryRemoveLiquidity(inputs)
+    const queryOutput = await handler.simulate(inputs)
 
-    const result = await handler.buildRemoveLiquidityCallData({ ...defaultBuildInput, queryOutput })
+    const result = await handler.buildCallData({ ...defaultBuildInput, queryOutput })
 
     expect(result.to).toBe(networkConfig.contracts.balancer.vaultV2)
     expect(result.data).toBeDefined()

--- a/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
@@ -29,7 +29,7 @@ export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler
     this.helpers = new LiquidityActionHelpers(pool)
   }
 
-  public async queryRemoveLiquidity({
+  public async simulate({
     humanBptIn,
     tokenOut,
   }: QueryRemoveLiquidityInput): Promise<SdkQueryRemoveLiquidityOutput> {
@@ -44,7 +44,7 @@ export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler
     return { amountsOut: sdkQueryOutput.amountsOut, sdkQueryOutput }
   }
 
-  public async calculatePriceImpact({
+  public async getPriceImpact({
     humanBptIn,
     tokenOut,
   }: QueryRemoveLiquidityInput): Promise<number> {
@@ -67,7 +67,7 @@ export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler
     return priceImpactABA.decimal
   }
 
-  public async buildRemoveLiquidityCallData({
+  public async buildCallData({
     account,
     slippagePercent,
     queryOutput,

--- a/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityBuildCallDataQuery.ts
+++ b/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityBuildCallDataQuery.ts
@@ -49,7 +49,7 @@ export function useRemoveLiquidityBuildCallDataQuery({
 
   const queryFn = async () => {
     const queryOutput = ensureLastQueryResponse('Remove liquidity query', simulationQuery.data)
-    const res = await handler.buildRemoveLiquidityCallData({
+    const res = await handler.buildCallData({
       account: userAddress,
       slippagePercent: slippage,
       queryOutput,

--- a/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityPriceImpactQuery.ts
+++ b/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityPriceImpactQuery.ts
@@ -33,7 +33,7 @@ export function useRemoveLiquidityPriceImpactQuery(
   })
 
   const queryFn = async () =>
-    handler.calculatePriceImpact({
+    handler.getPriceImpact({
       humanBptIn: debouncedBptIn,
       tokenOut,
     })

--- a/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquiditySimulationQuery.ts
+++ b/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquiditySimulationQuery.ts
@@ -37,7 +37,7 @@ export function useRemoveLiquiditySimulationQuery(
   })
 
   const queryFn = async () =>
-    handler.queryRemoveLiquidity({
+    handler.simulate({
       humanBptIn: debouncedHumanBptIn,
       tokenOut,
     })

--- a/lib/modules/web3/contracts/useManagedSendTransaction.integration.spec.ts
+++ b/lib/modules/web3/contracts/useManagedSendTransaction.integration.spec.ts
@@ -44,9 +44,9 @@ describe('weighted join test', () => {
       tokenAddress: t.address,
     }))
 
-    const queryOutput = await handler.queryAddLiquidity(humanAmountsIn)
+    const queryOutput = await handler.simulate(humanAmountsIn)
 
-    const txConfig = await handler.buildAddLiquidityCallData({
+    const txConfig = await handler.buildCallData({
       humanAmountsIn,
       account: defaultTestUserAccount,
       slippagePercent: '0.2',


### PR DESCRIPTION
# Description

I don't think handler names need to include the higher level concept. It's implied by the handler usage. If there is a case where it's not clear then the handler variable should be renamed, e.g. `addLiquidityHandler.simulate(...)` instead of `handler.simulateAddLiquidity`.

## Type of change

- [x] Code refactor / cleanup

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
