### PR TITLE
Avoid timeout if the step is not active

### DIFF
--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -54,6 +54,7 @@ export function RemoveLiquidityForm() {
     isDisabled,
     disabledReason,
     simulationQuery,
+    deactivateFinalStep,
   } = useRemoveLiquidity()
   const { toCurrency } = useCurrency()
   const nextBtn = useRef(null)
@@ -70,6 +71,11 @@ export function RemoveLiquidityForm() {
     if (option.value === 'single') {
       setSingleTokenType()
     }
+  }
+
+  const onModalClose = () => {
+    previewModalDisclosure.onClose()
+    deactivateFinalStep()
   }
 
   return (
@@ -148,7 +154,7 @@ export function RemoveLiquidityForm() {
           finalFocusRef={nextBtn}
           isOpen={previewModalDisclosure.isOpen}
           onOpen={previewModalDisclosure.onOpen}
-          onClose={previewModalDisclosure.onClose}
+          onClose={onModalClose}
         />
       </Center>
     </TokenBalancesProvider>

--- a/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityTimeout.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityTimeout.tsx
@@ -23,7 +23,7 @@ function useRemoveLiquidityTimeout() {
     buildCallDataQuery,
     previewModalDisclosure,
     removeLiquidityTransaction,
-    isActiveStep,
+    isFinalStepActive,
   } = useRemoveLiquidity()
 
   const transactionState = getTransactionState(removeLiquidityTransaction)
@@ -33,11 +33,9 @@ function useRemoveLiquidityTimeout() {
   const isComplete = transactionState === TransactionState.Completed
 
   // Disable query refetches:
-  // if the final step is not active
   // if the flow is complete
   // if the remove liquidity transaction is confirming
-  const shouldFreezeQuote =
-    !isActiveStep || isComplete || isConfirmingRemoveLiquidity || isAwaitingUserConfirmation
+  const shouldFreezeQuote = isComplete || isConfirmingRemoveLiquidity || isAwaitingUserConfirmation
 
   // When the countdown timer reaches 0, refetch all remove liquidity queries.
   useEffect(() => {
@@ -45,7 +43,7 @@ function useRemoveLiquidityTimeout() {
       stopCountdown()
       resetCountdown()
       await Promise.all([simulationQuery.refetch(), priceImpactQuery.refetch()])
-      await buildCallDataQuery.refetch()
+      if (isFinalStepActive) await buildCallDataQuery.refetch() // Avoid this refetch if the final step is not active (for example, when approval pre steps are active)
       startCountdown()
     }
     if (secondsToRefetch === 0 && !shouldFreezeQuote) refetchQueries()

--- a/lib/modules/pool/actions/remove-liquidity/useRemoveLiquidity.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/useRemoveLiquidity.tsx
@@ -29,7 +29,11 @@ export function _useRemoveLiquidity() {
   const { pool, bptPrice } = usePool()
   const { getToken, usdValueForToken } = useTokens()
   const { isConnected } = useUserAccount()
-  const { isActiveStep, activateStep, deactivateStep } = useActiveStep()
+  const {
+    isActiveStep: isFinalStepActive,
+    activateStep: activateFinalStep,
+    deactivateStep: deactivateFinalStep,
+  } = useActiveStep()
   const previewModalDisclosure = useDisclosure()
 
   const [removalType, setRemovalType] = useState<RemoveLiquidityType>(
@@ -86,7 +90,7 @@ export function _useRemoveLiquidity() {
     tokenOut: singleTokenOutAddress,
     simulationQuery,
     options: {
-      enabled: isActiveStep,
+      enabled: isFinalStepActive,
     },
   })
 
@@ -96,7 +100,7 @@ export function _useRemoveLiquidity() {
   const { removeLiquidityStep, removeLiquidityTransaction } = useConstructRemoveLiquidityStep(
     pool.id,
     buildCallDataQuery,
-    activateStep
+    activateFinalStep
   )
   const steps = [removeLiquidityStep]
 
@@ -153,12 +157,12 @@ export function _useRemoveLiquidity() {
     priceImpactQuery,
     buildCallDataQuery,
     isDisabled,
-    isActiveStep,
+    isFinalStepActive,
+    deactivateFinalStep,
     disabledReason,
     steps,
     previewModalDisclosure,
     removeLiquidityTransaction,
-    deactivateStep,
     setRemovalType,
     setHumanBptInPercent,
     setProportionalType,


### PR DESCRIPTION
# Description

Adds condition to avoid timeout `buildCallData` refetch when the final step is not enabled. 
* We only have one step in remove liquidity flow but we will have more steps like Relayer related in incoming PRs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
