### PR TITLE
chore: update GHA actions to use node > 16 and avoid warnings

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,9 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         version: latest
+        node-version: 18
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: pnpm
         node-version: 18

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run build
@@ -19,7 +19,7 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run lint
@@ -32,7 +32,7 @@ jobs:
   Unit-Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run typecheck
@@ -43,7 +43,7 @@ jobs:
   Integration-Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Set up foundry (includes anvil)


### PR DESCRIPTION
# Description

See title. 

Avoid warnings like: 

<img width="1567" alt="warnings" src="https://github.com/balancer/frontend-v3/assets/1316240/6974c1df-8326-452d-a309-42af5bf4d32d">



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
