### PR TITLE
chore: allow getToken passing only tokenAddress and using current chain

### DIFF
--- a/lib/modules/tokens/useTokens.spec.tsx
+++ b/lib/modules/tokens/useTokens.spec.tsx
@@ -1,7 +1,6 @@
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { testHook } from '@/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
-import { Address } from 'viem'
 import {
   defaultGetTokenPricesQueryMock,
   defaultGetTokensQueryMock,
@@ -9,6 +8,7 @@ import {
   defaultTokenListMock,
 } from './__mocks__/token.builders'
 import { _useTokens } from './useTokens'
+import { balAddress, wETHAddress } from '@/lib/debug-helpers'
 
 const initTokensData = defaultGetTokensQueryMock
 const initTokenPricesData = defaultGetTokenPricesQueryMock
@@ -30,10 +30,48 @@ test('fetches tokens', async () => {
   expect(result.current.tokens).toEqual(defaultTokenListMock)
 })
 
-test('gets tokens by token address', async () => {
+test('gets a token by token address and chain', async () => {
   const result = testUseTokens()
 
-  const tokenAddresses = ['0xba100000625a3754423978a60c9317c58a424e3d' as Address]
+  expect(result.current.getToken(wETHAddress, GqlChain.Mainnet)).toMatchInlineSnapshot(`
+    {
+      "__typename": "GqlToken",
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "chain": "MAINNET",
+      "chainId": 1,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "name": "Wrapped Ether",
+      "priority": 0,
+      "symbol": "WETH",
+      "tradable": true,
+    }
+  `)
+})
+
+test('gets a token by token address and current chain when chain is not provided', async () => {
+  const result = testUseTokens()
+
+  expect(result.current.getToken(wETHAddress, GqlChain.Mainnet)).toMatchInlineSnapshot(`
+    {
+      "__typename": "GqlToken",
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "chain": "MAINNET",
+      "chainId": 1,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+      "name": "Wrapped Ether",
+      "priority": 0,
+      "symbol": "WETH",
+      "tradable": true,
+    }
+  `)
+})
+
+test('gets a list of tokens from a list of token addresses', async () => {
+  const result = testUseTokens()
+
+  const tokenAddresses = [balAddress]
 
   expect(result.current.getTokensByTokenAddress(tokenAddresses, GqlChain.Mainnet))
     .toMatchInlineSnapshot(`

--- a/lib/modules/tokens/useTokens.tsx
+++ b/lib/modules/tokens/useTokens.tsx
@@ -56,9 +56,10 @@ export function _useTokens(
     It can return undefined when the token address belongs to a pool token (not included in the provided tokens)
     // TODO: should we avoid calling getToken with pool tokens?
    */
-  function getToken(address: string, chain: GqlChain | number): GqlToken | undefined {
-    const chainKey = typeof chain === 'number' ? 'chainId' : 'chain'
-    return tokens.find(token => isSameAddress(token.address, address) && token[chainKey] === chain)
+  function getToken(address: string, chain?: GqlChain | number): GqlToken | undefined {
+    const _chain = chain ?? networkConfig.chain
+    const chainKey = typeof _chain === 'number' ? 'chainId' : 'chain'
+    return tokens.find(token => isSameAddress(token.address, address) && token[chainKey] === _chain)
   }
 
   const getTokensByChain = useCallback(


### PR DESCRIPTION
# Description

Simplifies `useTokens` -> `getToken` signature by making the `chain` parameter optional (and using the current chain when chain is not provided) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
