### PR TITLE
feat: Popular token select

### DIFF
--- a/app/(app)/debug/token-input/page.tsx
+++ b/app/(app)/debug/token-input/page.tsx
@@ -3,7 +3,7 @@
 import { useTokens } from '@/lib/modules/tokens/useTokens'
 import { TokenInput } from '@/lib/modules/tokens/TokenInput/TokenInput'
 import { Button, Card, Heading, Text, VStack, useDisclosure } from '@chakra-ui/react'
-import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { useState } from 'react'
 import { TokenSelectModal } from '@/lib/modules/tokens/TokenSelectModal/TokenSelectModal'
 import { TokenBalancesProvider } from '@/lib/modules/tokens/useTokenBalances'
@@ -47,6 +47,7 @@ export default function TokenInputPage() {
 
         <TokenSelectModal
           tokens={tokens}
+          chain={GqlChain.Mainnet}
           isOpen={tokenSelectDisclosure.isOpen}
           onOpen={tokenSelectDisclosure.onOpen}
           onClose={tokenSelectDisclosure.onClose}

--- a/app/(app)/debug/token-select/page.tsx
+++ b/app/(app)/debug/token-select/page.tsx
@@ -3,7 +3,7 @@
 import { TokenSelectModal } from '@/lib/modules/tokens/TokenSelectModal/TokenSelectModal'
 import { TokenBalancesProvider } from '@/lib/modules/tokens/useTokenBalances'
 import { useTokens } from '@/lib/modules/tokens/useTokens'
-import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { Button, useDisclosure, Text } from '@chakra-ui/react'
 import { useRef, useState } from 'react'
 
@@ -26,6 +26,7 @@ export default function TokenSelectPage() {
       </Button>
       <TokenSelectModal
         tokens={getTokensByChain(1)}
+        chain={GqlChain.Mainnet}
         pinNativeAsset
         finalFocusRef={tokenSelectBtn}
         isOpen={tokenSelectDisclosure.isOpen}

--- a/lib/config/config.types.ts
+++ b/lib/config/config.types.ts
@@ -14,6 +14,7 @@ export interface TokensConfig {
     tokenIn?: Address
     tokenOut?: Address
   }
+  popularTokens?: Address[]
 }
 
 export interface ContractsConfig {

--- a/lib/config/networks/mainnet.ts
+++ b/lib/config/networks/mainnet.ts
@@ -27,6 +27,15 @@ const networkConfig: NetworkConfig = {
     defaultSwapTokens: {
       tokenIn: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     },
+    popularTokens: [
+      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', // ETH
+      '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+      '0x6B175474E89094C44Da98b954EedeAC495271d0F', // DAI
+      '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT
+      '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
+      '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
+    ],
   },
   contracts: {
     multicall2: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',

--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -162,6 +162,7 @@ export function SwapForm() {
       </Center>
       <TokenSelectModal
         tokens={tokenSelectTokens}
+        chain={selectedChain}
         isOpen={tokenSelectDisclosure.isOpen}
         onOpen={tokenSelectDisclosure.onOpen}
         onClose={tokenSelectDisclosure.onClose}

--- a/lib/modules/tokens/TokenSelectModal/TokenSelectModal.tsx
+++ b/lib/modules/tokens/TokenSelectModal/TokenSelectModal.tsx
@@ -10,13 +10,16 @@ import {
   ModalHeader,
   ModalOverlay,
   ModalProps,
+  VStack,
 } from '@chakra-ui/react'
 import { RefObject, useRef, useState } from 'react'
 import { TokenSelectList } from './TokenSelectList/TokenSelectList'
-import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { TokenSelectPopular } from './TokenSelectPopular'
 
 type Props = {
   tokens: GqlToken[]
+  chain: GqlChain
   excludeNativeAsset?: boolean
   pinNativeAsset?: boolean
   isOpen: boolean
@@ -28,6 +31,7 @@ type Props = {
 
 export function TokenSelectModal({
   tokens,
+  chain,
   excludeNativeAsset = false,
   pinNativeAsset = false,
   isOpen,
@@ -60,24 +64,35 @@ export function TokenSelectModal({
         <ModalHeader>Select a token</ModalHeader>
         <ModalCloseButton />
         <ModalBody p={0}>
-          <Box px="md">
-            <Input
-              ref={initialFocusRef}
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              placeholder="Search by name, symbol or address"
-            />
-          </Box>
-          <Box p="md" pr="0">
-            <TokenSelectList
-              tokens={tokens}
-              excludeNativeAsset={excludeNativeAsset}
-              pinNativeAsset={pinNativeAsset}
-              listHeight={500}
-              searchTerm={searchTerm}
-              onTokenSelect={closeOnSelect}
-            />
-          </Box>
+          <VStack w="full" align="start" spacing="md">
+            <Box px="md" w="full">
+              <Input
+                ref={initialFocusRef}
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                placeholder="Search by name, symbol or address"
+              />
+            </Box>
+            {!searchTerm && (
+              <Box px="md" w="full">
+                <TokenSelectPopular
+                  chain={chain}
+                  excludeNativeAsset={excludeNativeAsset}
+                  onTokenSelect={closeOnSelect}
+                />
+              </Box>
+            )}
+            <Box px="md" pr="0" w="full">
+              <TokenSelectList
+                tokens={tokens}
+                excludeNativeAsset={excludeNativeAsset}
+                pinNativeAsset={pinNativeAsset}
+                listHeight={500}
+                searchTerm={searchTerm}
+                onTokenSelect={closeOnSelect}
+              />
+            </Box>
+          </VStack>
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/lib/modules/tokens/TokenSelectModal/TokenSelectPopular.tsx
+++ b/lib/modules/tokens/TokenSelectModal/TokenSelectPopular.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { getNetworkConfig } from '@/lib/config/app.config'
+import { GqlChain, GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { HStack, Tag, Text, Wrap, WrapItem } from '@chakra-ui/react'
+import { useTokens } from '../useTokens'
+import { useMemo } from 'react'
+import { TokenIcon } from '../TokenIcon'
+
+type Props = {
+  chain: GqlChain
+  excludeNativeAsset?: boolean
+  onTokenSelect: (token: GqlToken) => void
+}
+
+export function TokenSelectPopular({ chain, excludeNativeAsset, onTokenSelect }: Props) {
+  const {
+    tokens: { popularTokens },
+  } = getNetworkConfig(chain)
+  const { getToken, nativeAssetFilter } = useTokens()
+
+  const tokens = useMemo(() => {
+    const tokens = popularTokens?.map(token => getToken(token, chain)).filter(Boolean) as GqlToken[]
+    return excludeNativeAsset ? tokens.filter(nativeAssetFilter) : tokens
+  }, [popularTokens, excludeNativeAsset, chain])
+
+  return (
+    <Wrap>
+      {tokens?.map(token => (
+        <WrapItem key={token.address}>
+          <Tag
+            key={token.address}
+            onClick={() => onTokenSelect(token)}
+            size="lg"
+            pl="xs"
+            cursor="pointer"
+          >
+            <HStack>
+              <TokenIcon address={token.address} chain={chain} size={22} alt={token.symbol} />
+              <Text>{token.symbol}</Text>
+            </HStack>
+          </Tag>
+        </WrapItem>
+      ))}
+    </Wrap>
+  )
+}

--- a/lib/shared/services/chakra/theme.ts
+++ b/lib/shared/services/chakra/theme.ts
@@ -1299,7 +1299,15 @@ export const balTheme = {
     },
     Tag: {
       baseStyle: {
-        bg: 'background: #EFEDE6',
+        container: {
+          background: 'background.card.level1',
+          shadow: 'md',
+          borderColor: 'border.base',
+          borderWidth: '1px',
+          borderRadius: 'full',
+          color: 'font.primary',
+          fontWeight: 'semibold',
+        },
       },
     },
   },


### PR DESCRIPTION
# Description

Adds easy popular token selection to top of token select modal as per designs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Test token select modal on swap page.

## Visual context
<img width="522" alt="Screenshot 2024-02-09 at 15 52 35" src="https://github.com/balancer/frontend-v3/assets/2406506/73e0d14a-8235-42ea-9dcc-eb461c1f7ba3">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
