### PR TITLE
fix: remove filling timestamps for pools older than 30 days

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolChart/usePoolCharts.tsx
+++ b/lib/modules/pool/PoolDetail/PoolChart/usePoolCharts.tsx
@@ -323,12 +323,12 @@ export function usePoolCharts() {
 
     // add lagging timestamps
     if (!isPoolOlder30Days && chartArr.length < 30 && chartArr.length > MIN_CHART_VALUES_NUM) {
-      const lastDate = chartArr[chartArr.length - 1][0] || 0
+      const firstDate = chartArr[0][0] || 0
       const days = 30 - chartArr.length
 
       const timestampsArr: number[] = []
       for (let i = 1; i <= days; i++) {
-        const timestamp = Number(lastDate) - i * twentyFourHoursInSecs
+        const timestamp = Number(firstDate) - i * twentyFourHoursInSecs
         timestampsArr.push(timestamp * 1000)
       }
 

--- a/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
+++ b/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
@@ -22,7 +22,7 @@ export function PoolComposition() {
   }, [pool])
 
   return (
-    <Card variant="gradient" width="full" height="320px">
+    <Card variant="gradient" width="full">
       <VStack spacing="0" width="full">
         <HStack width="full" p="4" justifyContent="space-between">
           <Heading fontWeight="bold" size="h5">


### PR DESCRIPTION
# Description
Filling timestamps logic works properly only for new pools, so this pr disables it for pools older than 30 days.
discussion: https://balancerecosystem.slack.com/archives/C05H1NS8Q8L/p1707921181394789
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
