### PR TITLE
feat: proportional remove liquidity in Gyro pools

### DIFF
--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -29,6 +29,7 @@ import { RemoveLiquiditySingleToken } from './RemoveLiquiditySingleToken'
 import { usePool } from '../../../usePool'
 import { usePoolRedirect } from '../../../pool.hooks'
 import { TransactionSettings } from '@/lib/modules/user/settings/TransactionSettings'
+import { requiresProportionalInput } from '../../LiquidityActionHelpers'
 
 const TABS: ButtonGroupOption[] = [
   {
@@ -98,17 +99,19 @@ export function RemoveLiquidityForm() {
               </Heading>
               <TransactionSettings size="sm" />
             </HStack>
-            <HStack>
-              <ButtonGroup
-                currentOption={activeTab}
-                options={TABS}
-                onChange={toggleTab}
-                size="lg"
-              />
-              <Tooltip label="Remove liquidity type" fontSize="sm">
-                <InfoOutlineIcon color="grayText" />
-              </Tooltip>
-            </HStack>
+            {!requiresProportionalInput && (
+              <HStack>
+                <ButtonGroup
+                  currentOption={activeTab}
+                  options={TABS}
+                  onChange={toggleTab}
+                  size="lg"
+                />
+                <Tooltip label="Remove liquidity type" fontSize="sm">
+                  <InfoOutlineIcon color="grayText" />
+                </Tooltip>
+              </HStack>
+            )}
             <VStack w="full" spacing="md">
               <InputWithSlider
                 value={totalUsdValue}


### PR DESCRIPTION
# Description

We already supported Proportional remove liquidity so we just need to hide the Proportional/Single token for pools that only support proportional type (Gyro v2 pools for now).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
