### PR TITLE
fix: fix chainId and network config in userTokenBalances multicall 

### DIFF
--- a/lib/modules/tokens/useTokenBalances.tsx
+++ b/lib/modules/tokens/useTokenBalances.tsx
@@ -23,7 +23,8 @@ export function _useTokenBalances(tokens: TokenBase[]) {
   const { userAddress } = useUserAccount()
   const { exclNativeAssetFilter, nativeAssetFilter } = useTokens()
 
-  const chainId = tokens.length ? tokens[0].chainId : 1
+  const NO_TOKENS_CHAIN_ID = 1 // this should never be used as the multicall is disabled when no tokens
+  const chainId = tokens.length ? tokens[0].chainId : NO_TOKENS_CHAIN_ID
   const networkConfig = getNetworkConfig(chainId)
 
   const includesNativeAsset = tokens.some(nativeAssetFilter)


### PR DESCRIPTION
# Description

Before: 
userTokenBalances multicall was using `chainId` and `networkConfig` from the current connected network (`useNetwork config`).

After:
now it  uses `chainId` and `networkConfig` from the provided tokens instead (it gets it from the first token).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
