### PR TITLE
fix: token address error when navigating from poolA to poolB

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/useAddLiquidity.tsx
+++ b/lib/modules/pool/actions/add-liquidity/useAddLiquidity.tsx
@@ -6,7 +6,6 @@ import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { isSameAddress } from '@/lib/shared/utils/addresses'
 import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { safeSum } from '@/lib/shared/utils/numbers'
-import { makeVar, useReactiveVar } from '@apollo/client'
 import { HumanAmount } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useEffect, useMemo, useState } from 'react'
 import { Address } from 'viem'
@@ -27,10 +26,8 @@ import { useIterateSteps } from '../useIterateSteps'
 export type UseAddLiquidityResponse = ReturnType<typeof _useAddLiquidity>
 export const AddLiquidityContext = createContext<UseAddLiquidityResponse | null>(null)
 
-export const humanAmountsInVar = makeVar<HumanAmountIn[]>([])
-
 export function _useAddLiquidity() {
-  const humanAmountsIn = useReactiveVar(humanAmountsInVar)
+  const [humanAmountsIn, setHumanAmountsIn] = useState<HumanAmountIn[]>([])
 
   const { pool } = usePool()
   const { getToken, usdValueForToken } = useTokens()
@@ -63,14 +60,12 @@ export function _useAddLiquidity() {
           humanAmount: '',
         } as HumanAmountIn)
     )
-    humanAmountsInVar(amountsIn)
+    setHumanAmountsIn(amountsIn)
   }
 
   function setHumanAmountIn(tokenAddress: Address, humanAmount: HumanAmount) {
-    const state = humanAmountsInVar()
-
-    humanAmountsInVar([
-      ...state.filter(amountIn => !isSameAddress(amountIn.tokenAddress, tokenAddress)),
+    setHumanAmountsIn([
+      ...humanAmountsIn.filter(amountIn => !isSameAddress(amountIn.tokenAddress, tokenAddress)),
       {
         tokenAddress,
         humanAmount,
@@ -129,6 +124,7 @@ export function _useAddLiquidity() {
     handler,
     addLiquidityTxState,
     setHumanAmountIn,
+    setHumanAmountsIn,
     setAddLiquidityTxState,
   }
 }


### PR DESCRIPTION
# Description

**Before:** 

We were using a global exported `humanAmountsInVar` that was initialised with `setInitialHumanAmountsIn` in a useEffect.

The problem is that when navigating from poolA to poolB, the global `humanAmountsInVar` from poolA was kept, causing a bug when running `_useAddLiquidity` for poolB tokens with old poolA tokens before `setInitialHumanAmountsIn` was called. 

https://github.com/balancer/frontend-v3/assets/1316240/0f39eeb0-fbcb-403d-b907-fc5d9bb781b9

**After:** 
We didn't actually need a global reactive apollo var. Just using a local useState enforces that `humanAmountsIn` are empty in every pool navigation. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
