### PR TITLE
remove bpt from charts

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/BoostedPoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/BoostedPoolWeightChart.tsx
@@ -6,7 +6,7 @@ import EChartsReactCore from 'echarts-for-react/lib/core'
 import * as echarts from 'echarts/core'
 import { motion } from 'framer-motion'
 import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
-import { ChartSizeValues, PoolWeightChartProps } from './PoolWeightChart'
+import { ChartSizeValues, PoolTokensWeightChartProps } from './PoolWeightChart'
 import PoolWeightChartLegend from './PoolWeightChartLegend'
 
 const smallSize: ChartSizeValues = {
@@ -30,12 +30,12 @@ const normalSize: ChartSizeValues = {
 }
 
 export default function BoostedPoolWeightChart({
-  pool,
+  tokens,
   chain,
   hasLegend,
   isSmall,
   colors = [],
-}: PoolWeightChartProps) {
+}: PoolTokensWeightChartProps) {
   const chartSizeValues = isSmall ? smallSize : normalSize
   const eChartsRef = useRef<EChartsReactCore | null>(null)
   const [isChartLoaded, setIsChartLoaded] = useState(false)
@@ -72,7 +72,7 @@ export default function BoostedPoolWeightChart({
           labelLine: {
             show: false,
           },
-          data: pool.tokens.map((token, i) => ({
+          data: tokens.map((token, i) => ({
             value: 33,
             name: token.symbol,
             emphasis: {},
@@ -160,7 +160,7 @@ export default function BoostedPoolWeightChart({
           mx="auto"
           justifyContent="center"
         >
-          <PoolWeightChartLegend pool={pool} colors={colors} />
+          <PoolWeightChartLegend tokens={tokens} colors={colors} />
         </HStack>
       )}
     </VStack>

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/CLPPoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/CLPPoolWeightChart.tsx
@@ -1,6 +1,6 @@
 import { Box, HStack, Grid, useColorMode, Flex } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
-import { ChartSizeValues, PoolWeightChartProps } from './PoolWeightChart'
+import { ChartSizeValues, PoolTokensWeightChartProps } from './PoolWeightChart'
 import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
 import PoolWeightChartLegend from './PoolWeightChartLegend'
 
@@ -48,24 +48,24 @@ const chartSizes: Record<string, Record<string, ChartSizeValues>> = {
 }
 
 export default function CLPPoolWeightChart({
-  pool,
+  tokens,
   chain,
   hasLegend,
   isSmall,
   colors = [],
-}: PoolWeightChartProps) {
+}: PoolTokensWeightChartProps) {
   const { colorMode } = useColorMode()
 
   function getChartSizeValues() {
     const chartSizeKey = isSmall ? 'small' : 'normal'
-    if (pool.tokens.length === 2) {
+    if (tokens.length === 2) {
       return chartSizes.diamond[chartSizeKey]
     }
     return chartSizes.square[chartSizeKey]
   }
 
   function getLegendOffset() {
-    if (pool.tokens.length === 2) {
+    if (tokens.length === 2) {
       return '-5rem'
     }
     return '-4rem'
@@ -128,7 +128,7 @@ export default function CLPPoolWeightChart({
             </filter>
           </defs>
         </svg>
-        {pool.tokens.length === 2 && (
+        {tokens.length === 2 && (
           <Box filter="url(#round)">
             <Box
               bgGradient={`linear(to-r, ${colors[0].from}, ${colors[0].to})`}
@@ -154,7 +154,7 @@ export default function CLPPoolWeightChart({
             />
           </Box>
         )}
-        {pool.tokens.length === 3 && (
+        {tokens.length === 3 && (
           <HStack
             spacing="0"
             zIndex={1}
@@ -163,12 +163,12 @@ export default function CLPPoolWeightChart({
             rounded="2xl"
             transform="rotate(-135deg)"
           >
-            {pool.tokens.map((_, i) => {
+            {tokens.map((token, i) => {
               return (
                 <Box
                   borderColor={`chartBorder.${colorMode}`}
                   borderWidth="1px"
-                  key={`${pool.address}-token-weight-${i}`}
+                  key={`${token.address}-token-weight-${i}`}
                   as={motion.div}
                   cursor="pointer"
                   width="full"
@@ -177,19 +177,19 @@ export default function CLPPoolWeightChart({
                   _hover={{ filter: 'brightness(103%)' }}
                   borderTopLeftRadius={i === 0 ? 'xl' : 'none'}
                   borderBottomLeftRadius={i === 0 ? 'xl' : 'none'}
-                  borderTopRightRadius={i === pool.tokens.length - 1 ? 'xl' : 'none'}
-                  borderBottomRightRadius={i === pool.tokens.length - 1 ? 'xl' : 'none'}
+                  borderTopRightRadius={i === tokens.length - 1 ? 'xl' : 'none'}
+                  borderBottomRightRadius={i === tokens.length - 1 ? 'xl' : 'none'}
                 />
               )
             })}
           </HStack>
         )}
-        {pool.tokens.length === 4 && (
+        {tokens.length === 4 && (
           <Grid zIndex={1} templateColumns="1fr 1fr" width="full" height="full" rounded="2xl">
-            {pool.tokens.map((_, i) => {
+            {tokens.map((token, i) => {
               return (
                 <Box
-                  key={`${pool.address}-token-weight-${i}`}
+                  key={`${token.address}-token-weight-${i}`}
                   as={motion.div}
                   cursor="pointer"
                   bgGradient={`linear(to-b, ${colors[i].from}, ${colors[i].to})`}
@@ -215,7 +215,7 @@ export default function CLPPoolWeightChart({
             mx="auto"
             justifyContent="center"
           >
-            <PoolWeightChartLegend pool={pool} colors={colors} />
+            <PoolWeightChartLegend tokens={tokens} colors={colors} />
           </HStack>
         )}
       </Box>

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
@@ -1,18 +1,30 @@
 import { Box } from '@chakra-ui/react'
 import React from 'react'
 import WeightedPoolWeightChart from './WeightedPoolWeightChart'
-import { GqlChain, GqlPoolStable, GqlPoolUnion } from '@/lib/shared/services/api/generated/graphql'
+import {
+  GqlChain,
+  GqlPoolToken,
+  GqlPoolTokenUnion,
+  GqlPoolUnion,
+} from '@/lib/shared/services/api/generated/graphql'
 import { isBoosted, isClp, isStable } from '../../pool.helpers'
 import BoostedPoolWeightChart from './BoostedPoolWeightChart'
 import StablePoolWeightChart from './StablePoolWeightChart'
 import CLPPoolWeightChart from './CLPPoolWeightChart'
 
-export interface PoolWeightChartProps {
-  pool: GqlPoolUnion
+export interface PoolWeightChartPropsBase {
   chain: GqlChain
   hasLegend?: boolean
   isSmall?: boolean
   colors?: PoolWeightChartColorDef[]
+}
+
+export interface PoolWeightChartProps extends PoolWeightChartPropsBase {
+  pool: GqlPoolUnion
+}
+
+export interface PoolTokensWeightChartProps extends PoolWeightChartPropsBase {
+  tokens: GqlPoolTokenUnion[] | GqlPoolToken[]
 }
 
 export interface ChartSizeValues {
@@ -73,17 +85,20 @@ export default function PoolWeightChart({
     isSmall,
     colors: DEFAULT_POOL_WEIGHT_CHART_COLORS,
   }
+
+  const filteredTokens = pool.tokens.filter(token => token.address !== pool.address)
+
   if (isBoosted(pool)) {
-    return <BoostedPoolWeightChart pool={pool as GqlPoolStable} {...commonProps} />
+    return <BoostedPoolWeightChart tokens={filteredTokens} {...commonProps} />
   }
   if (isStable(pool.type)) {
-    return <StablePoolWeightChart pool={pool as GqlPoolStable} {...commonProps} />
+    return <StablePoolWeightChart tokens={filteredTokens} {...commonProps} />
   }
   if (isClp(pool.type)) {
-    return <CLPPoolWeightChart pool={pool as GqlPoolStable} {...commonProps} />
+    return <CLPPoolWeightChart tokens={filteredTokens} {...commonProps} />
   }
   if (pool.__typename === 'GqlPoolWeighted') {
-    return <WeightedPoolWeightChart pool={pool} {...commonProps} />
+    return <WeightedPoolWeightChart tokens={filteredTokens} {...commonProps} />
   }
   return <Box minH="150px"></Box>
 }

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartLegend.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartLegend.tsx
@@ -1,33 +1,34 @@
-import { GqlPoolUnion } from '@/lib/shared/services/api/generated/graphql'
+import { GqlPoolToken, GqlPoolTokenUnion } from '@/lib/shared/services/api/generated/graphql'
 import { Box, HStack, Text } from '@chakra-ui/react'
 import { PoolWeightChartColorDef } from './PoolWeightChart'
 
 export default function PoolWeightChartLegend({
-  pool,
+  tokens,
   colors = [],
 }: {
-  pool: GqlPoolUnion
+  tokens: GqlPoolTokenUnion[] | GqlPoolToken[]
   colors?: PoolWeightChartColorDef[]
 }) {
   return (
     <HStack spacing="6">
-      {pool.tokens.map((token, i) => {
-        return (
-          <Box
-            fontWeight="normal"
-            fontSize="1rem"
-            background="none"
-            key={`token-weight-chart-legend-${token.symbol}`}
-          >
-            <HStack>
-              <Box width="8px" height="8px" bg={colors[i].from} rounded="full" />
-              <Text whiteSpace="nowrap" color="gray.400">
-                {token.symbol}
-              </Text>
-            </HStack>
-          </Box>
-        )
-      })}
+      {tokens &&
+        tokens.map((token, i) => {
+          return (
+            <Box
+              fontWeight="normal"
+              fontSize="1rem"
+              background="none"
+              key={`token-weight-chart-legend-${token.symbol}`}
+            >
+              <HStack>
+                <Box width="8px" height="8px" bg={colors[i].from} rounded="full" />
+                <Text whiteSpace="nowrap" color="gray.400">
+                  {token.symbol}
+                </Text>
+              </HStack>
+            </Box>
+          )
+        })}
     </HStack>
   )
 }

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/StablePoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/StablePoolWeightChart.tsx
@@ -1,6 +1,6 @@
 import { Box, HStack, Grid, useColorMode, Flex } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
-import { ChartSizeValues, PoolWeightChartProps } from './PoolWeightChart'
+import { ChartSizeValues, PoolTokensWeightChartProps } from './PoolWeightChart'
 import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
 import PoolWeightChartLegend from './PoolWeightChartLegend'
 
@@ -25,14 +25,15 @@ const normalSize: ChartSizeValues = {
 }
 
 export default function StablePoolWeightChart({
-  pool,
+  tokens,
   chain,
   hasLegend,
   colors = [],
   isSmall,
-}: PoolWeightChartProps) {
+}: PoolTokensWeightChartProps) {
   const chartSizeValues = isSmall ? smallSize : normalSize
   const { colorMode } = useColorMode()
+
   return (
     <Flex
       position="relative"
@@ -68,14 +69,14 @@ export default function StablePoolWeightChart({
         >
           <PoolWeightChartChainIcon chain={chain} isChartLoaded={true} isSmall={isSmall} />
         </Box>
-        {pool.tokens.length <= 3 && (
+        {tokens.length <= 3 && (
           <HStack spacing="0" zIndex={1} width="full" height="full" rounded="2xl">
-            {pool.tokens.map((_, i) => {
+            {tokens.map((token, i) => {
               return (
                 <Box
                   borderColor={`chartBorder.${colorMode}`}
                   borderWidth="1px"
-                  key={`${pool.address}-token-weight-${i}`}
+                  key={`${token.address}-token-weight-${i}`}
                   as={motion.div}
                   cursor="pointer"
                   width="full"
@@ -84,19 +85,19 @@ export default function StablePoolWeightChart({
                   _hover={{ filter: 'brightness(103%)' }}
                   borderTopLeftRadius={i === 0 ? 'xl' : 'none'}
                   borderBottomLeftRadius={i === 0 ? 'xl' : 'none'}
-                  borderTopRightRadius={i === pool.tokens.length - 1 ? 'xl' : 'none'}
-                  borderBottomRightRadius={i === pool.tokens.length - 1 ? 'xl' : 'none'}
+                  borderTopRightRadius={i === tokens.length - 1 ? 'xl' : 'none'}
+                  borderBottomRightRadius={i === tokens.length - 1 ? 'xl' : 'none'}
                 />
               )
             })}
           </HStack>
         )}
-        {pool.tokens.length === 4 && (
+        {tokens.length === 4 && (
           <Grid zIndex={1} templateColumns="1fr 1fr" width="full" height="full" rounded="2xl">
-            {pool.tokens.map((_, i) => {
+            {tokens.map((token, i) => {
               return (
                 <Box
-                  key={`${pool.address}-token-weight-${i}`}
+                  key={`${token.address}-token-weight-${i}`}
                   as={motion.div}
                   cursor="pointer"
                   bgGradient={`linear(to-b, ${colors[i].from}, ${colors[i].to})`}
@@ -122,7 +123,7 @@ export default function StablePoolWeightChart({
             mx="auto"
             justifyContent="center"
           >
-            <PoolWeightChartLegend pool={pool} colors={colors} />
+            <PoolWeightChartLegend tokens={tokens} colors={colors} />
           </HStack>
         )}
       </Box>

--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/WeightedPoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/WeightedPoolWeightChart.tsx
@@ -5,7 +5,7 @@ import ReactECharts from 'echarts-for-react'
 import EChartsReactCore from 'echarts-for-react/lib/core'
 import * as echarts from 'echarts/core'
 import { motion } from 'framer-motion'
-import { ChartSizeValues, PoolWeightChartProps } from './PoolWeightChart'
+import { ChartSizeValues, PoolTokensWeightChartProps } from './PoolWeightChart'
 import PoolWeightChartChainIcon from './PoolWeightChartChainIcon'
 import PoolWeightChartLegend from './PoolWeightChartLegend'
 
@@ -30,12 +30,12 @@ const normalSize: ChartSizeValues = {
 }
 
 export default function WeightedPoolWeightChart({
-  pool,
+  tokens,
   chain,
   hasLegend,
   isSmall,
   colors = [],
-}: PoolWeightChartProps) {
+}: PoolTokensWeightChartProps) {
   const chartSizeValues = isSmall ? smallSize : normalSize
   const eChartsRef = useRef<EChartsReactCore | null>(null)
   const [isChartLoaded, setIsChartLoaded] = useState(false)
@@ -83,7 +83,7 @@ export default function WeightedPoolWeightChart({
           emphasis: {
             scale: false,
           },
-          data: pool.tokens.map((token, i) => ({
+          data: tokens.map((token, i) => ({
             value: parseFloat(token.weight || '0') * 100,
             name: token.symbol,
             itemStyle: {
@@ -102,7 +102,7 @@ export default function WeightedPoolWeightChart({
         },
       ],
     }
-  }, [pool, colorMode])
+  }, [tokens, colorMode])
 
   return (
     <VStack>
@@ -147,7 +147,7 @@ export default function WeightedPoolWeightChart({
       </Box>
       {hasLegend && (
         <HStack mt="-4">
-          <PoolWeightChartLegend pool={pool} colors={colors} />
+          <PoolWeightChartLegend tokens={tokens} colors={colors} />
         </HStack>
       )}
     </VStack>


### PR DESCRIPTION
# Description

Don't show the bpt in the pool tokens weight charts.

![image](https://github.com/balancer/frontend-v3/assets/20125808/25cc9c16-8fa4-4b26-8ebe-70cdb26dc808)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
