### PR TITLE
refactor: avoid global reactive humanAmountInVar in useStaking

### DIFF
--- a/lib/modules/pool/actions/stake/useStaking.tsx
+++ b/lib/modules/pool/actions/stake/useStaking.tsx
@@ -4,21 +4,20 @@
 import { isDisabledWithReason } from '@/lib/shared/utils/functions/isDisabledWithReason'
 import { useUserAccount } from '@/lib/modules/web3/useUserAccount'
 import { LABELS } from '@/lib/shared/labels'
-import { makeVar, useReactiveVar } from '@apollo/client'
 import { HumanAmountIn } from '../liquidity-types'
 import { Address, parseUnits } from 'viem'
 import { useTokenAllowances } from '@/lib/modules/web3/useTokenAllowances'
 import { usePool } from '../../usePool'
 import { BPT_DECIMALS } from '../../pool.constants'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTokenApprovalConfigs } from '@/lib/modules/tokens/approvals/useTokenApprovalConfigs'
 import { stakeConfig } from './stakeConfig'
 import { useIterateSteps } from '../useIterateSteps'
 import { getChainId } from '@/lib/config/app.config'
 
-export const humanAmountInVar = makeVar<HumanAmountIn | null>(null)
-
 export function useStaking() {
+  const [humanAmountIn, setHumanAmountIn] = useState<HumanAmountIn | null>(null)
+
   const { userAddress, isConnected } = useUserAccount()
   const { pool } = usePool()
   const { isDisabled, disabledReason } = isDisabledWithReason([
@@ -26,15 +25,13 @@ export function useStaking() {
     LABELS.walletNotConnected,
   ])
 
-  const humanAmountIn = useReactiveVar(humanAmountInVar)
-
   function setInitialHumanAmountIn() {
     const amountIn = {
       tokenAddress: pool.address,
       humanAmount: pool.userBalance?.walletBalance,
     } as HumanAmountIn
 
-    humanAmountInVar(amountIn)
+    setHumanAmountIn(amountIn)
   }
 
   const tokenAllowances = useTokenAllowances({


### PR DESCRIPTION
# Description

Refactor in useStaking to avoid issues like the one fixed in #305.

We don't need a global apollo reactive var so better to keep it simple. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
