### PR TITLE
fix: PoolMyLiquidity token balances

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
+++ b/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
@@ -16,6 +16,7 @@ import { getProportionalExitAmountsFromScaledBptIn } from '../pool.utils'
 import { BPT_DECIMALS } from '../pool.constants'
 import { useUserAccount } from '../../web3/useUserAccount'
 import { bn } from '@/lib/shared/utils/numbers'
+import { hasNestedPools } from '../pool.helpers'
 
 const TABS = [
   {
@@ -113,6 +114,11 @@ export default function PoolMyLiquidity() {
   const hasUnstakedBalance = bn(pool.userBalance?.walletBalance || '0').gt(0)
   const hasStakedBalance = bn(pool.userBalance?.stakedBalance || '0').gt(0)
 
+  const displayTokens = hasNestedPools(pool)
+    ? // we don't have the balances for pool.displayTokens for v2 boosted pools so we show bpt tokens balance as a workaround
+      pool.tokens
+    : pool.displayTokens
+
   return (
     <Card variant="gradient" width="full" minHeight="320px">
       <VStack spacing="0" width="full">
@@ -150,7 +156,7 @@ export default function PoolMyLiquidity() {
                 </HStack>
               </Box>
               <VStack spacing="4" p="4" py="2" pb="4" width="full">
-                {pool.tokens.map(token => {
+                {displayTokens.map(token => {
                   return (
                     <TokenRow
                       chain={chain}


### PR DESCRIPTION
# Description

Fixes #349 

**Before:** 
Opening  (with connected account): https://v3.balancer.fi/pools/ethereum/v2/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe

failed because it tried to load balances for mainTokens (instead of bpt ones):
<img width="594" alt="bug" src="https://github.com/balancer/frontend-v3/assets/1316240/57a62e94-040f-44df-8a37-1973c51c413b">

**After**:

Now, it loads balances for the non nested bpt tokens (instead of the main tokens):

<img width="596" alt="Screenshot 2024-03-08 at 12 52 43" src="https://github.com/balancer/frontend-v3/assets/1316240/88bdac9c-4162-4364-978d-a6c7cfd66b52">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
