### PR TITLE
chore: Use config rpc urls for viem chains

### DIFF
--- a/lib/modules/web3/Web3Provider.tsx
+++ b/lib/modules/web3/Web3Provider.tsx
@@ -42,8 +42,8 @@ function buildChain(viemChain: Chain, rpcOverride?: string): Chain {
   return defineChain({
     ...viemChain,
     rpcUrls: {
-      default: { http: [rpcOverride || rpcUrl || viemChain.rpcUrls.default.http[0]] },
-      public: { http: [rpcOverride || rpcUrl || viemChain.rpcUrls.public.http[0]] },
+      default: { http: [rpcOverride || rpcUrl, ...viemChain.rpcUrls.default.http] },
+      public: { http: [rpcOverride || rpcUrl, ...viemChain.rpcUrls.public.http] },
     },
   })
 }


### PR DESCRIPTION
# Description

Uses config rpc urls for viem chain configs. So usePublicClient and other hooks are always using our paid RPC providers.

## Type of change

- [x] Code refactor / cleanup

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
