### PR TITLE
fix: filter out native asset from approval amounts

### DIFF
--- a/lib/modules/tokens/approvals/useTokenApprovalConfigs.tsx
+++ b/lib/modules/tokens/approvals/useTokenApprovalConfigs.tsx
@@ -12,7 +12,7 @@ import { useTokens } from '../useTokens'
 import { ApprovalAction } from './approval-labels'
 import { RawAmount, getRequiredTokenApprovals } from './approval-rules'
 import { ApproveTokenProps, useConstructApproveTokenStep } from './useConstructApproveTokenStep'
-import { getChainId, getNetworkConfig } from '@/lib/config/app.config'
+import { getChainId, getNativeAssetAddress, getNetworkConfig } from '@/lib/config/app.config'
 import { isSameAddress } from '@/lib/shared/utils/addresses'
 
 type Props = ApproveTokenProps & CommonStepProps
@@ -42,13 +42,11 @@ export function useTokenApprovalConfigs({
 }: Params): StepConfig[] {
   const { userAddress } = useUserAccount()
   const { getToken } = useTokens()
-  const {
-    tokens: { nativeAsset },
-  } = getNetworkConfig(chain)
+  const nativeAssetAddress = getNativeAssetAddress(chain)
 
   const _approvalAmounts = approvalAmounts
     .filter(amount => amount.rawAmount > 0)
-    .filter(amount => !isSameAddress(amount.address, nativeAsset.address))
+    .filter(amount => !isSameAddress(amount.address, nativeAssetAddress))
 
   const approvalTokenAddresses = _approvalAmounts.map(amount => amount.address)
 


### PR DESCRIPTION
# Description

We don't need to approve the native asset so just make sure it's filtered out when constructing token approval steps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
