### PR TITLE
feat: Auto set wrap tokens

### DIFF
--- a/lib/modules/swap/useSwap.tsx
+++ b/lib/modules/swap/useSwap.tsx
@@ -24,7 +24,12 @@ import { useIterateSteps } from '../transactions/transaction-steps/useIterateSte
 import { isSameAddress } from '@/lib/shared/utils/addresses'
 import { useVault } from '@/lib/shared/hooks/useVault'
 import { NativeWrapHandler } from './handlers/NativeWrap.handler'
-import { getWrapHandlerClass, isNativeWrap, isSupportedWrap } from './wrap.helpers'
+import {
+  getWrapHandlerClass,
+  getWrapperForBaseToken,
+  isNativeWrap,
+  isSupportedWrap,
+} from './wrap.helpers'
 
 export type UseSwapResponse = ReturnType<typeof _useSwap>
 export const SwapContext = createContext<UseSwapResponse | null>(null)
@@ -273,11 +278,24 @@ export function _useSwap() {
     swapStateVar(getDefaultTokenState(swapState.selectedChain))
   }, [])
 
+  // When a new simulation is triggered, update the state
   useEffect(() => {
     if (simulationQuery.data) {
       handleSimulationResponse(simulationQuery.data)
     }
   }, [simulationQuery.data])
+
+  // Check if tokenIn is a base wrap token and set tokenOut as the wrapped token.
+  useEffect(() => {
+    const wrapper = getWrapperForBaseToken(swapState.tokenIn.address, swapState.selectedChain)
+    if (wrapper) setTokenOut(wrapper.wrappedToken)
+  }, [swapState.tokenIn.address])
+
+  // Check if tokenOut is a base wrap token and set tokenIn as the wrapped token.
+  useEffect(() => {
+    const wrapper = getWrapperForBaseToken(swapState.tokenOut.address, swapState.selectedChain)
+    if (wrapper) setTokenIn(wrapper.wrappedToken)
+  }, [swapState.tokenOut.address])
 
   const { isDisabled, disabledReason } = isDisabledWithReason(
     [!isConnected, LABELS.walletNotConnected],

--- a/lib/modules/swap/wrap.helpers.ts
+++ b/lib/modules/swap/wrap.helpers.ts
@@ -63,3 +63,9 @@ export function getWrapType(tokenIn: Address, tokenOut: Address, chain: GqlChain
 
   return null
 }
+
+export function getWrapperForBaseToken(baseToken: Address, chain: GqlChain) {
+  const networkConfig = getNetworkConfig(chain)
+  const supportedWrappers = networkConfig.tokens.supportedWrappers || []
+  return supportedWrappers.find(wrapper => isSameAddress(wrapper.baseToken, baseToken))
+}


### PR DESCRIPTION
# Description

Auto sets the opposite token as the wrapped version of a wrap token. e.g. if the token selected is stETH then the opposite token is always set to wstETH. This is until we can support relayer, like the Lido relayer which would let you swap stETH for other tokens directly.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Set tokenIn as stETH, tokenOut should be auto set to wstETH
- [ ] Set tokenOut as stETH, tokenIn should be auto set to wstETH

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
