### PR TITLE
chore: add RPC url env vars to integration tests in CI

### DIFF
--- a/test/anvil/anvil-setup.ts
+++ b/test/anvil/anvil-setup.ts
@@ -47,7 +47,6 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
   POLYGON: {
     networkName: 'POLYGON',
     rpcEnv: 'NEXT_POLYGON_RPC_URL',
-    // Public Polygon RPCs are usually unreliable
     fallBackRpc: getNetworkConfig(GqlChain.Polygon).rpcUrl,
     port: ANVIL_PORTS.POLYGON,
     // Note - this has to be >= highest blockNo used in tests
@@ -57,7 +56,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
     networkName: 'FANTOM',
     rpcEnv: 'NEXT_FANTOM_RPC_URL',
     // Public Fantom RPCs are usually unreliable
-    fallBackRpc: undefined,
+    fallBackRpc: getNetworkConfig(GqlChain.Fantom).rpcUrl,
     port: ANVIL_PORTS.FANTOM,
     forkBlockNumber: 65313450n,
   },


### PR DESCRIPTION
# Description

Our integration tests are starting to be slow. Using real RPC_URL instead of the default fallbacks will be much faster.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
