### PR TITLE
chore: add sentry DSN for development

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,10 +3,10 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
-import { sentryDns } from './sentry.config'
+import { sentryDSN } from './sentry.config'
 
 Sentry.init({
-  dsn: sentryDns,
+  dsn: sentryDSN,
 
   // Set to 0% to turn off.
   tracesSampleRate: 0,

--- a/sentry.config.js
+++ b/sentry.config.js
@@ -37,14 +37,14 @@ const sentryOptions = {
 }
 
 const isProd = process.env.NEXT_PUBLIC_APP_ENV === 'prod'
-const productionSentryDns =
+const productionSentryDSN =
   'https://53df88eafd8f9a546b0e926b65553379@o574636.ingest.sentry.io/4506382607712256'
-const developmentSentryDns =
+const developmentSentryDSN =
   'https://28291a3b50d248e06f917aa5a98b8fea@o574636.ingest.us.sentry.io/4506944362053632'
-const sentryDns = isProd ? productionSentryDns : developmentSentryDns
+const sentryDSN = isProd ? productionSentryDSN : developmentSentryDSN
 
 module.exports = {
   sentryWebpackPluginOptions,
   sentryOptions,
-  sentryDns,
+  sentryDSN,
 }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,10 +4,10 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
-import { sentryDns } from './sentry.config'
+import { sentryDSN } from './sentry.config'
 
 Sentry.init({
-  dsn: sentryDns,
+  dsn: sentryDSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,10 +3,10 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
-import { sentryDns } from './sentry.config'
+import { sentryDSN } from './sentry.config'
 
 Sentry.init({
-  dsn: sentryDns,
+  dsn: sentryDSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
 


### PR DESCRIPTION
# Description

Now we have 2 apps in sentry: `frontend-v3` and `frontend-v3-develop`

- All prod builds will send errors to `frontend-v3` (for now, that includes vercel preview url errors)
- All non-prod builds (i.e. localhost development errors) will send errors to `frontend-v3-develop`

I also setup sentry `frontend-v3` like this: 
<img width="1237" alt="Screenshot 2024-03-21 at 15 39 48" src="https://github.com/balancer/frontend-v3/assets/1316240/db44a370-ebe1-441d-8994-18c6027c24d3">

In the future we can improve captureError functions to be safer and turn off sentry errors in development (like in v2) but, for now, this setup is easy and useful to test sentry setups in development.

**TODO**: enable 2 slack channels for production errors: 
- One for fatal errors
- One for non-fatal errors

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
