### PR TITLE
fix: set network Card width to auto in PoolActionsNav

### DIFF
--- a/lib/modules/pool/actions/PoolActionsNav.tsx
+++ b/lib/modules/pool/actions/PoolActionsNav.tsx
@@ -64,7 +64,7 @@ export function PoolActionsNav() {
 
   return (
     <HStack justify="space-between">
-      <Card variant="level2" p="sm">
+      <Card variant="level2" p="sm" width="auto">
         <Image src={networkConfig.iconPath} width="24" height="24" alt={networkConfig.shortName} />
       </Card>
       <ButtonGroup


### PR DESCRIPTION
# Description

Theme Card changes had broken the PoolActionsNav styles:
<img width="1897" alt="before" src="https://github.com/balancer/frontend-v3/assets/1316240/c0d1e610-62c4-4ec3-b367-8c31c215d84f">

After the fix: 

<img width="1901" alt="Screenshot 2024-04-01 at 12 20 35" src="https://github.com/balancer/frontend-v3/assets/1316240/7251bdc1-0e33-4041-a14d-156d3352fd46">

 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
