### PR TITLE
Fix stable chart spacing

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolWeightCharts/StablePoolWeightChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolWeightCharts/StablePoolWeightChart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Box, HStack, Grid, Flex, useTheme } from '@chakra-ui/react'
+import { Box, HStack, Grid, Flex, useTheme, VStack } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 import { ChartSizeValues, PoolWeightChartProps } from './PoolWeightChart'
 import Image from 'next/image'
@@ -89,12 +89,14 @@ export default function StablePoolWeightChart({
   const colorMode = useThemeColorMode()
 
   return (
-    <Flex
+    <VStack
+      mt={isSmall ? '0' : '8'}
       position="relative"
       width="full"
       height="full"
       justifyContent="center"
       alignItems="center"
+      spacing="4"
     >
       <Box
         width={`${chartSizeValues.boxWidth * 0.75}px`}
@@ -200,20 +202,12 @@ export default function StablePoolWeightChart({
             })}
           </Grid>
         )}
-        {hasLegend && (
-          <HStack
-            width="full"
-            bottom="-2.5rem"
-            position="absolute"
-            left="0"
-            right="0"
-            mx="auto"
-            justifyContent="center"
-          >
-            <PoolWeightChartLegend pool={pool} colors={colors} />
-          </HStack>
-        )}
       </Box>
-    </Flex>
+      {hasLegend && (
+        <HStack width="full" justifyContent="center">
+          <PoolWeightChartLegend pool={pool} colors={colors} />
+        </HStack>
+      )}
+    </VStack>
   )
 }


### PR DESCRIPTION
# Description

Spacing for stable pool weight chart

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Stable pools, check it out

## Visual context
<img width="1301" alt="image" src="https://github.com/balancer/frontend-v3/assets/40786269/06e841d8-7d89-4b9f-ac4e-7a653dab704d">


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
