### PR TITLE
fix: tokenFormat for small amounts

### DIFF
--- a/lib/shared/utils/numbers.spec.ts
+++ b/lib/shared/utils/numbers.spec.ts
@@ -30,11 +30,12 @@ describe('fiatFormat', () => {
 
 describe('tokenFormat', () => {
   test('Abbreviated formats', () => {
-    expect(fNum('token', '0.000000000000000001')).toBe('0')
-    expect(fNum('token', '0.0000001')).toBe('0')
-    expect(fNum('token', '0.000000493315290277')).toBe('0')
     expect(fNum('token', '0.001')).toBe('0.001')
     expect(fNum('token', '0.006')).toBe('0.006')
+    expect(fNum('token', '0.0001')).toBe('0.0001')
+    expect(fNum('token', '0.00001')).toBe('< 0.00001')
+    expect(fNum('token', '0.0000001')).toBe('< 0.00001')
+    expect(fNum('token', '0.000000493315290277')).toBe('< 0.00001')
     expect(fNum('token', '0.012345')).toBe('0.0123')
     expect(fNum('token', '0.123456789')).toBe('0.1235')
     expect(fNum('token', '0')).toBe('0')

--- a/lib/shared/utils/numbers.ts
+++ b/lib/shared/utils/numbers.ts
@@ -66,7 +66,7 @@ function fiatFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): st
 
 // Formats a token value.
 function tokenFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): string {
-  if (bn(val).lt(bn('0.000001'))) return '0'
+  if (!bn(val).isZero() && bn(val).lte(bn('0.00001'))) return '< 0.00001'
   const format = abbreviated ? TOKEN_FORMAT_A : TOKEN_FORMAT
   return numeral(toSafeValue(val)).format(format)
 }


### PR DESCRIPTION
# Description

We had a NaN bug when formatting dust amounts:

![dustNaN](https://github.com/balancer/frontend-v3/assets/1316240/50dd6ba6-55d7-4ade-80dd-3bfae778b7c9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
