### PR TITLE
fix: use isLazy in settings popovers to avoid input overlap

### DIFF
--- a/lib/modules/user/settings/TransactionSettings.tsx
+++ b/lib/modules/user/settings/TransactionSettings.tsx
@@ -25,7 +25,7 @@ export function TransactionSettings(props: ButtonProps) {
   const { slippage } = useUserSettings()
 
   return (
-    <Popover placement="bottom-end">
+    <Popover placement="bottom-end" isLazy>
       <PopoverTrigger>
         <Button variant="tertiary" {...props}>
           <HStack textColor="grayText">

--- a/lib/modules/user/settings/UserSettings.tsx
+++ b/lib/modules/user/settings/UserSettings.tsx
@@ -77,7 +77,7 @@ const signaturesTooltipLabel = `It's recommended to turn on signatures for gas-f
 
 export function UserSettings() {
   return (
-    <Popover>
+    <Popover isLazy>
       <PopoverTrigger>
         <Button variant="tertiary" p="0">
           <Settings size={18} />


### PR DESCRIPTION
# Description

`TransactionSettings` component contains a `CurrencySelect` in the `PopoverContent`. That select has a react select input underneath.

From [Chakra docs](https://chakra-ui.com/docs/components/popover#lazily-mounting-popover):  
> By default, the Popover component renders children of PopoverContent to the DOM, meaning that invisible popover contents are still rendered but are hidden by styles.

Due that behaviour we were having an overlap between the invisible react select input and the current visible token input, affecting the UX as these image and video shows: 

![invisible-react-select](https://github.com/balancer/frontend-v3/assets/1316240/964dd977-34ba-41bb-af52-ab83f5d3cc6e)

https://github.com/balancer/frontend-v3/assets/1316240/7b8261f9-6348-4175-b930-cfcf05221b78

Adding `isLazy` prop solves the issue.





## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
