### PR TITLE
fix: use only supported chains on portfolio page

### DIFF
--- a/lib/modules/portfolio/usePortfolio.tsx
+++ b/lib/modules/portfolio/usePortfolio.tsx
@@ -12,6 +12,7 @@ import BigNumber from 'bignumber.js'
 import { Address } from 'viem'
 import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { useUserAccount } from '../web3/useUserAccount'
+import { PROJECT_CONFIG } from '@/lib/config/getProjectConfig'
 
 export interface ClaimableBalanceResult {
   status: 'success' | 'error'
@@ -49,7 +50,12 @@ function _usePortfolio() {
   const { userAddress, isConnected } = useUserAccount()
 
   const { data, loading } = useApolloQuery(GetPoolsDocument, {
-    variables: { where: { userAddress } },
+    variables: {
+      where: {
+        userAddress,
+        chainIn: PROJECT_CONFIG.supportedNetworks,
+      },
+    },
     notifyOnNetworkStatusChange: true,
     skip: !isConnected || !userAddress,
   })


### PR DESCRIPTION
# Description
We should fetch pools only for supported chains in portfolio page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
