### PR TITLE
fix: only show badge when mnTvl > 0

### DIFF
--- a/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -169,14 +169,16 @@ export function FilterTags() {
           <TagCloseButton onClick={() => toggleNetwork(false, network)} />
         </Tag>
       ))}
-      <Tag key="minTvl" size="lg">
-        <TagLabel>
-          <Text fontWeight="bold" textTransform="capitalize">
-            {`TVL > ${toCurrency(minTvl)}`}
-          </Text>
-        </TagLabel>
-        <TagCloseButton onClick={() => setMinTvl(0)} />
-      </Tag>
+      {minTvl > 0 && (
+        <Tag key="minTvl" size="lg">
+          <TagLabel>
+            <Text fontWeight="bold" textTransform="capitalize">
+              {`TVL > ${toCurrency(minTvl)}`}
+            </Text>
+          </TagLabel>
+          <TagCloseButton onClick={() => setMinTvl(0)} />
+        </Tag>
+      )}
     </HStack>
   )
 }


### PR DESCRIPTION
# Description

Only show the minTvl filter badge when minTvl > 0

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test
configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static
screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
