### PR TITLE
fix: disable enter key in SearchInput

### DIFF
--- a/lib/shared/components/inputs/SearchInput.tsx
+++ b/lib/shared/components/inputs/SearchInput.tsx
@@ -51,6 +51,11 @@ export function SearchInput({
           shadow: 'input.innerFocus',
           color: 'input.fontFocus',
         }}
+        onKeyDown={event => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+          }
+        }}
         {...rest}
       />
       <InputRightElement>


### PR DESCRIPTION
Hitting `enter` in the pool search list input was reloading the whole page. 
Added a fix to disable enter.