### PR TITLE
fix: use 2 decimals for abbreviated tokens greater than 1000

### DIFF
--- a/lib/shared/utils/numbers.spec.ts
+++ b/lib/shared/utils/numbers.spec.ts
@@ -45,8 +45,9 @@ describe('tokenFormat', () => {
     expect(fNum('token', '10.1234')).toBe('10.1234')
     expect(fNum('token', '100')).toBe('100')
     expect(fNum('token', '123.456')).toBe('123.456')
-    expect(fNum('token', '12345')).toBe('12.345k')
-    expect(fNum('token', '123456789.12345678')).toBe('123.4568m')
+    expect(fNum('token', '12345')).toBe('12.35k')
+    expect(fNum('token', '2157.12345')).toBe('2.16k')
+    expect(fNum('token', '123456789.12345678')).toBe('123.46m')
   })
 
   test('Non-abbreviated formats', () => {

--- a/lib/shared/utils/numbers.ts
+++ b/lib/shared/utils/numbers.ts
@@ -20,6 +20,8 @@ export const INTEGER_FORMAT = '0,0'
 export const FIAT_FORMAT_A = '0,0.00a'
 export const FIAT_FORMAT = '0,0.00'
 export const TOKEN_FORMAT_A = '0,0.[0000]a'
+// Uses 2 decimals then value is > thousand
+export const TOKEN_FORMAT_A_BIG = '0,0.[00]a'
 export const TOKEN_FORMAT = '0,0.[0000]'
 export const APR_FORMAT = '0.[00]%'
 export const SLIPPAGE_FORMAT = '0.00%'
@@ -71,7 +73,11 @@ function fiatFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): st
 // Formats a token value.
 function tokenFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): string {
   if (!bn(val).isZero() && bn(val).lte(bn('0.00001'))) return '< 0.00001'
-  const format = abbreviated ? TOKEN_FORMAT_A : TOKEN_FORMAT
+
+  // Uses 2 decimals then value is > thousand
+  const TOKEN_FORMAT_ABBREVIATED = bn(val).gte(bn('1000')) ? TOKEN_FORMAT_A_BIG : TOKEN_FORMAT_A
+  const format = abbreviated ? TOKEN_FORMAT_ABBREVIATED : TOKEN_FORMAT
+
   return numeral(toSafeValue(val)).format(format)
 }
 


### PR DESCRIPTION
When the token amount is > 1000 displays 2 decimals (instead of 4) in the abbreviated format.

Before: 
`2157.12345` was displayed as` 2.1571k`

After:
`2157.12345` is displayed as `2.16k`
