### PR TITLE
refactor: push invalid dynamic swap route to force reload

### DIFF
--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -29,7 +29,7 @@ import { ChainSelect } from '../chains/ChainSelect'
 import { CheckCircle, Link, Repeat } from 'react-feather'
 import { SwapRate } from './SwapRate'
 import { SwapDetails } from './SwapDetails'
-import { capitalize } from 'lodash'
+import { capitalize, now } from 'lodash'
 import { motion, easeOut } from 'framer-motion'
 import FadeInOnView from '@/lib/shared/components/containers/FadeInOnView'
 import { ErrorAlert } from '@/lib/shared/components/errors/ErrorAlert'
@@ -101,7 +101,10 @@ export function SwapForm() {
   function onModalClose() {
     previewModalDisclosure.onClose()
     if (swapTxHash) {
-      router.back()
+      // We are going to reload the swap page with the same inputs again so, we need to refetch the simulation
+      simulationQuery.refetch()
+      // Push an invalid dynamic route to force a re-render of the swap layout
+      router.push(`/swap/${now()}`)
     }
   }
 


### PR DESCRIPTION
Replaces router.back by a router.push to improve the UX when going back to swap page from swap receipt.

There is still a little flicker but we improve a little bit. Here you can see 2 swaps in a row (with the same parameters):
 
https://github.com/balancer/frontend-v3/assets/1316240/ee46b3da-4ee4-4085-ab7d-3534d9dab44e

