### PR TITLE
fix: improve formatting of small amounts and percentages (including toCurrency)

### DIFF
--- a/lib/shared/hooks/useCurrency.spec.tsx
+++ b/lib/shared/hooks/useCurrency.spec.tsx
@@ -1,0 +1,49 @@
+import { testHook } from '@/test/utils/custom-renderers'
+import { useCurrency } from './useCurrency'
+
+import { PropsWithChildren } from 'react'
+import { FxRatesContext } from './FxRatesProvider'
+
+export function MockFiatFxRatesProvider({ children }: PropsWithChildren) {
+  const hook = {
+    hasFxRates: false,
+    getFxRate: () => 1, // mock that always return 1 as Fx rate
+  }
+  return <FxRatesContext.Provider value={hook}>{children}</FxRatesContext.Provider>
+}
+
+function testUseCurrency() {
+  const { result } = testHook(() => useCurrency(), { wrapper: MockFiatFxRatesProvider })
+  return result
+}
+
+describe('toCurrency', () => {
+  const result = testUseCurrency()
+
+  test('with not small amount', () => {
+    expect(result.current.toCurrency('1.23456789')).toBe('$1.23')
+    expect(result.current.toCurrency('0.01')).toBe('$0.01')
+  })
+
+  test('with small amount', () => {
+    expect(result.current.toCurrency('0.001')).toBe('<$0.001')
+    expect(result.current.toCurrency('0.000001234')).toBe('<$0.001')
+  })
+})
+
+test('formatCurrency', () => {
+  const result = testUseCurrency()
+
+  expect(result.current.formatCurrency('1.23456789')).toBe('$1.23456789')
+  expect(result.current.formatCurrency('0.01')).toBe('$0.01')
+  expect(result.current.formatCurrency('0.001')).toBe('$0.001')
+  expect(result.current.formatCurrency('0.000001234')).toBe('$0.000001234')
+})
+test('formatCurrency', () => {
+  const result = testUseCurrency()
+
+  expect(result.current.parseCurrency('0')).toBe('0')
+  expect(result.current.parseCurrency('1.23456789')).toBe('1.23456789')
+  expect(result.current.parseCurrency('$1.23456789')).toBe('1.23456789')
+  expect(result.current.parseCurrency('0.000001234')).toBe('0.000001234')
+})

--- a/lib/shared/hooks/useCurrency.ts
+++ b/lib/shared/hooks/useCurrency.ts
@@ -37,6 +37,10 @@ export function useCurrency() {
     const convertedAmount = toUserCurrency(usdVal)
     const formattedAmount = fNum('fiat', convertedAmount, { abbreviated })
 
+    if (formattedAmount.startsWith('<')) {
+      return withSymbol ? '<' + symbol + formattedAmount.substring(1) : formattedAmount
+    }
+
     return withSymbol ? symbol + formattedAmount : formattedAmount
   }
 

--- a/lib/shared/utils/numbers.spec.ts
+++ b/lib/shared/utils/numbers.spec.ts
@@ -1,4 +1,4 @@
-import { BN_LOWER_THRESHOLD, bn, fNum, safeTokenFormat } from './numbers'
+import { bn, fNum, safeTokenFormat, BN_LOWER_THRESHOLD } from './numbers'
 
 test('Stringifies bigints', () => {
   expect(JSON.stringify(12345n)).toBe('"12345"')
@@ -6,8 +6,9 @@ test('Stringifies bigints', () => {
 
 describe('fiatFormat', () => {
   test('Abbreviated formats', () => {
-    expect(fNum('fiat', '0.000000000000000001')).toBe('0.00')
-    expect(fNum('fiat', '0.001')).toBe('0.00')
+    expect(fNum('fiat', '0.000000000000000001')).toBe('<0.001')
+    expect(fNum('fiat', '0.00013843061948487287')).toBe('<0.001')
+    expect(fNum('fiat', '0.001')).toBe('<0.001')
     expect(fNum('fiat', '0.006')).toBe('0.01')
     expect(fNum('fiat', '0.012345')).toBe('0.01')
     expect(fNum('fiat', '0.123456789')).toBe('0.12')
@@ -81,13 +82,13 @@ describe('bn', () => {
 test('all formats types do not break with super small inputs (AKA dust)', () => {
   const dust = BN_LOWER_THRESHOLD
   expect(fNum('apr', dust)).toBe('0.00%')
-  expect(fNum('feePercent', dust)).toBe('0%')
-  expect(fNum('fiat', dust)).toBe('0.00')
+  expect(fNum('feePercent', dust)).toBe('<0.01%')
+  expect(fNum('fiat', dust)).toBe('<0.001')
   expect(fNum('integer', dust)).toBe('0')
-  expect(fNum('percentage', dust)).toBe('0%')
-  expect(fNum('priceImpact', dust)).toBe('0%')
-  expect(fNum('sharePercent', dust)).toBe('0%')
-  expect(fNum('slippage', dust)).toBe('0%')
+  expect(fNum('percentage', dust)).toBe('<0.01%')
+  expect(fNum('priceImpact', dust)).toBe('<0.01%')
+  expect(fNum('sharePercent', dust)).toBe('<0.01%')
+  expect(fNum('slippage', dust)).toBe('<0.01%')
   expect(fNum('token', dust)).toBe('< 0.00001')
-  expect(fNum('weight', dust)).toBe('0%')
+  expect(fNum('weight', dust)).toBe('<0.01%')
 })

--- a/lib/shared/utils/numbers.ts
+++ b/lib/shared/utils/numbers.ts
@@ -35,8 +35,16 @@ export const INTEGER_PERCENTAGE_FORMAT = '0%'
 // These can arise from pools with extremely low balances (e.g., completed LBPs)
 export const APR_UPPER_THRESHOLD = 1_000_000
 export const APR_LOWER_THRESHOLD = 0.0000001
-// Do not display bn values lower than this amount; they are likely to be generate NaN results
+
+// Do not display bn values lower than this amount; they are likely to generate NaN results
 export const BN_LOWER_THRESHOLD = 0.000001
+
+// Display <0.001 for small amounts
+export const AMOUNT_LOWER_THRESHOLD = 0.001
+export const SMALL_AMOUNT_LABEL = '<0.001'
+// Display <0.01% for small percentages
+export const PERCENTAGE_LOWER_THRESHOLD = 0.01
+export const SMALL_PERCENTAGE_LABEL = '<0.01%'
 
 const NUMERAL_DECIMAL_LIMIT = 9
 
@@ -60,13 +68,13 @@ function toSafeValue(val: Numberish): string {
 
 // Formats an integer value.
 function integerFormat(val: Numberish): string {
-  if (isDust(val)) return '0'
+  if (isSmallAmount(val)) return '0'
   return numeral(toSafeValue(val)).format(INTEGER_FORMAT)
 }
 
 // Formats a fiat value.
 function fiatFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): string {
-  if (isDust(val)) return '0.00'
+  if (isSmallAmount(val)) return SMALL_AMOUNT_LABEL
   const format = abbreviated ? FIAT_FORMAT_A : FIAT_FORMAT
   return numeral(toSafeValue(val)).format(format)
 }
@@ -92,32 +100,32 @@ function aprFormat(apr: Numberish): string {
 
 // Formats a slippage value as a percentage.
 function slippageFormat(slippage: Numberish): string {
-  if (isDust(slippage)) return '0%'
+  if (isSmallPercentage(slippage)) return SMALL_PERCENTAGE_LABEL
   return numeral(bn(slippage).div(100)).format(SLIPPAGE_FORMAT)
 }
 
 // Formats a fee value as a percentage.
 function feePercentFormat(fee: Numberish): string {
-  if (isDust(fee)) return '0%'
+  if (isSmallPercentage(fee)) return SMALL_PERCENTAGE_LABEL
   return numeral(fee.toString()).format(FEE_FORMAT)
 }
 
 // Formats a weight value as a percentage.
 function weightFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): string {
-  if (isDust(val)) return '0%'
+  if (isSmallPercentage(val)) return SMALL_PERCENTAGE_LABEL
   const format = abbreviated ? WEIGHT_FORMAT : WEIGHT_FORMAT_TWO_DECIMALS
   return numeral(val.toString()).format(format)
 }
 
 // Formats a price impact value as a percentage.
 function priceImpactFormat(val: Numberish): string {
-  if (isDust(val)) return '0%'
+  if (isSmallPercentage(val)) return SMALL_PERCENTAGE_LABEL
   return numeral(val.toString()).format(PRICE_IMPACT_FORMAT)
 }
 
 // Formats an integer value as a percentage.
 function integerPercentageFormat(val: Numberish): string {
-  if (isDust(val)) return '0%'
+  if (isSmallPercentage(val)) return SMALL_PERCENTAGE_LABEL
   return numeral(val.toString()).format(INTEGER_PERCENTAGE_FORMAT)
 }
 
@@ -170,7 +178,15 @@ export function fNum(format: NumberFormat, val: Numberish, opts?: FormatOpts): s
   }
 }
 
-function isDust(value: Numberish): boolean {
+function isSmallAmount(value: Numberish): boolean {
+  return !isZero(value) && bn(value).lte(AMOUNT_LOWER_THRESHOLD)
+}
+
+function isSmallPercentage(value: Numberish): boolean {
+  return !isZero(value) && bn(value).lte(PERCENTAGE_LOWER_THRESHOLD)
+}
+
+export function isSuperSmallAmount(value: Numberish): boolean {
   return bn(value).lte(BN_LOWER_THRESHOLD)
 }
 


### PR DESCRIPTION
We could add further improvements in another PR.

@pkattera's  suggestion for fiat:

If  less than, $0.0001, show <$0.0001
else, if between $0.01 and $0.0001, show 4 decimal points (e.g. $0.0045)
else show two decimal points (e.g. $2.05 or  $102,456.89)
