### PR TITLE
fix: Native asset swaps

### DIFF
--- a/lib/modules/swap/SwapProvider.tsx
+++ b/lib/modules/swap/SwapProvider.tsx
@@ -326,10 +326,9 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
     return parseUnits(amount, token.decimals)
   }
 
-  const isNativeAssetIn = isSameAddress(
-    swapState.tokenIn.address,
-    networkConfig.tokens.nativeAsset.address
-  )
+  const wethIsEth =
+    isSameAddress(swapState.tokenIn.address, networkConfig.tokens.nativeAsset.address) ||
+    isSameAddress(swapState.tokenOut.address, networkConfig.tokens.nativeAsset.address)
   const validAmountOut = bn(swapState.tokenOut.amount).gt(0)
 
   const vaultVersion = (simulationQuery.data as SdkSimulateSwapResponse)?.vaultVersion || 2
@@ -360,7 +359,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
     swapState,
     handler,
     simulationQuery,
-    isNativeAssetIn,
+    wethIsEth,
     swapAction,
     tokenInInfo,
     tokenOutInfo,
@@ -457,7 +456,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
     disabledReason,
     previewModalDisclosure,
     handler,
-    isNativeAssetIn,
+    wethIsEth,
     swapAction,
     urlTxHash,
     swapTxHash,

--- a/lib/modules/swap/handlers/DefaultSwap.handler.ts
+++ b/lib/modules/swap/handlers/DefaultSwap.handler.ts
@@ -53,14 +53,14 @@ export class DefaultSwapHandler implements SwapHandler {
     slippagePercent,
     account,
     selectedChain,
-    isNativeAssetIn,
+    wethIsEth,
   }: SdkBuildSwapInputs): TransactionConfig {
     const tx = swap.buildCall({
       slippage: Slippage.fromPercentage(slippagePercent as `${number}`),
       deadline: BigInt(Number.MAX_SAFE_INTEGER),
       sender: account,
       recipient: account,
-      wethIsEth: isNativeAssetIn,
+      wethIsEth,
       queryOutput,
     })
 

--- a/lib/modules/swap/queries/useBuildSwapQuery.ts
+++ b/lib/modules/swap/queries/useBuildSwapQuery.ts
@@ -13,7 +13,7 @@ export type BuildSwapQueryResponse = ReturnType<typeof useBuildSwapQuery>
 export type BuildSwapQueryParams = {
   handler: SwapHandler
   simulationQuery: SwapSimulationQueryResult
-  isNativeAssetIn: boolean
+  wethIsEth: boolean
   swapState: SwapState
 }
 
@@ -21,7 +21,7 @@ export type BuildSwapQueryParams = {
 export function useBuildSwapQuery({
   handler,
   simulationQuery,
-  isNativeAssetIn,
+  wethIsEth,
   swapState,
   enabled,
 }: BuildSwapQueryParams & {
@@ -50,7 +50,7 @@ export function useBuildSwapQuery({
       slippagePercent: slippage,
       selectedChain,
       simulateResponse,
-      isNativeAssetIn,
+      wethIsEth,
     })
     console.log('Swap callData built:', response)
 

--- a/lib/modules/swap/swap.types.ts
+++ b/lib/modules/swap/swap.types.ts
@@ -43,7 +43,7 @@ export interface BuildSwapInputs extends SwapState {
   account: Address
   slippagePercent: string
   simulateResponse: SimulateSwapResponse
-  isNativeAssetIn: boolean
+  wethIsEth: boolean
 }
 
 export interface SdkBuildSwapInputs extends BuildSwapInputs {

--- a/lib/modules/swap/useSwapStep.tsx
+++ b/lib/modules/swap/useSwapStep.tsx
@@ -28,7 +28,7 @@ export function useSwapStep({
   simulationQuery,
   swapState,
   swapAction,
-  isNativeAssetIn,
+  wethIsEth,
   tokenInInfo,
   tokenOutInfo,
 }: SwapStepParams): TransactionStep {
@@ -39,7 +39,7 @@ export function useSwapStep({
   const buildSwapQuery = useBuildSwapQuery({
     handler,
     simulationQuery,
-    isNativeAssetIn,
+    wethIsEth,
     swapState,
     enabled: isBuildQueryEnabled,
   })

--- a/lib/modules/swap/useSwapSteps.tsx
+++ b/lib/modules/swap/useSwapSteps.tsx
@@ -14,7 +14,7 @@ export function useSwapSteps({
   swapState,
   vaultAddress,
   handler,
-  isNativeAssetIn,
+  wethIsEth,
   simulationQuery,
   swapAction,
   tokenInInfo,
@@ -44,7 +44,7 @@ export function useSwapSteps({
 
   const swapStep = useSwapStep({
     handler,
-    isNativeAssetIn,
+    wethIsEth,
     swapState,
     simulationQuery,
     swapAction,


### PR DESCRIPTION
There was a bug where if you swapped a token to get the native asset out, e.g. a DAI > ETH swap you would get WETH instead. This was because of the wording of our variable vs the SDKs. The SDK variable is `wethIsEth` where as ours was `isNativeAssetIn`. So our conditional incorrectly only checked if the asset in was the native asset and not if the asset our was.