### PR TITLE
fix: Native asset receipts

### DIFF
--- a/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
+++ b/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
@@ -10,7 +10,9 @@ import { HumanTokenAmountWithAddress } from '../../tokens/token.types'
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { getChainId, getNativeAssetAddress, getNetworkConfig } from '@/lib/config/app.config'
 import { bn } from '@/lib/shared/utils/numbers'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
+import { emptyAddress } from '../../web3/contracts/wagmi-helpers'
+import { HumanAmount } from '@balancer/sdk'
 
 const userNotConnected = 'User is not connected'
 
@@ -88,11 +90,11 @@ export function useSwapReceipt({ txHash, userAddress, chain }: ReceiptProps & { 
   const sentTokenAddress = outgoingData?.address
   const sentToken = getToken(sentTokenAddress, chain)
 
-  const sentHumanAmountWithAddress = bn(sentTokenValue).gt(0)
+  const sentHumanAmountWithAddress: HumanTokenAmountWithAddress = bn(sentTokenValue).gt(0)
     ? _toHumanAmountWithAddress(sentTokenAddress, outgoingData?.args?.value, sentToken?.decimals)
     : bn(nativeAssetSent).gt(0)
     ? _toHumanAmountWithAddress(getNativeAssetAddress(chain), nativeAssetSent, 18)
-    : { tokenAddress: '', humanAmount: '' }
+    : { tokenAddress: emptyAddress, humanAmount: '0' as HumanAmount }
 
   /**
    * GET RECEIVED AMOUNT
@@ -108,7 +110,7 @@ export function useSwapReceipt({ txHash, userAddress, chain }: ReceiptProps & { 
     ? _toHumanAmountWithAddress(receivedTokenAddress, receivedTokenValue, receivedToken?.decimals)
     : bn(nativeAssetReceived).gt(0)
     ? _toHumanAmountWithAddress(getNativeAssetAddress(chain), nativeAssetReceived, 18)
-    : { tokenAddress: '', humanAmount: '' }
+    : { tokenAddress: emptyAddress, humanAmount: '0' as HumanAmount }
 
   if (!userAddress) {
     return {


### PR DESCRIPTION
Fixes swap receipt pages when the token in or out is the native asset. Previously the receipt pages would show a blank token with a 0 amount.

To test, on a L2:
1. Swap any token (not the wrapped native asset) for the native asset, does the receipt make sense?
2. Swap the native asset for any other token except the wrapped native asset, does the receipt make sense?