### PR TITLE
feat: filter on incentivized pools

### DIFF
--- a/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -32,7 +32,12 @@ import {
 import { PoolListSearch } from './PoolListSearch'
 import { getProjectConfig } from '@/lib/config/getProjectConfig'
 import { usePoolListQueryState } from './usePoolListQueryState'
-import { PoolFilterType, poolTypeFilters } from '../pool.types'
+import {
+  PoolFilterType,
+  poolTypeFilters,
+  PoolCategoryType,
+  poolCategoryFilters,
+} from '../pool.types'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { useEffect, useState } from 'react'
 import { Filter } from 'react-feather'
@@ -40,6 +45,7 @@ import { useBreakpoints } from '@/lib/shared/hooks/useBreakpoints'
 import { useCurrency } from '@/lib/shared/hooks/useCurrency'
 import { useDebouncedCallback } from 'use-debounce'
 import { defaultDebounceMs } from '@/lib/shared/utils/queries'
+import { getPoolCategoryLabel } from '../pool.utils'
 
 const SLIDER_MAX_VALUE = 10000000
 const SLIDER_STEP_SIZE = 100000
@@ -66,6 +72,27 @@ function UserPoolFilter() {
       <Text>Only show my pools</Text>
     </Checkbox>
   )
+}
+
+function PoolCategoryFilters() {
+  const { togglePoolCategory, poolCategories, setPoolCategories } = usePoolListQueryState()
+
+  // remove query param when empty
+  useEffect(() => {
+    if (!poolCategories.length) {
+      setPoolCategories(null)
+    }
+  }, [poolCategories])
+
+  return poolCategoryFilters.map(category => (
+    <Checkbox
+      key={category}
+      isChecked={!!poolCategories.find(selected => selected === category)}
+      onChange={e => togglePoolCategory(e.target.checked, category as PoolCategoryType)}
+    >
+      <Text>{getPoolCategoryLabel(category)}</Text>
+    </Checkbox>
+  ))
 }
 
 function PoolTypeFilters() {
@@ -150,11 +177,26 @@ function PoolMinTvlFilter() {
 }
 
 export function FilterTags() {
-  const { networks, toggleNetwork, poolTypes, togglePoolType, poolTypeLabel, minTvl, setMinTvl } =
-    usePoolListQueryState()
+  const {
+    networks,
+    toggleNetwork,
+    poolTypes,
+    togglePoolType,
+    poolTypeLabel,
+    minTvl,
+    setMinTvl,
+    poolCategories,
+    togglePoolCategory,
+    poolCategoryLabel,
+  } = usePoolListQueryState()
   const { toCurrency } = useCurrency()
 
-  if (networks.length === 0 && poolTypes.length === 0 && minTvl === 0) {
+  if (
+    networks.length === 0 &&
+    poolTypes.length === 0 &&
+    minTvl === 0 &&
+    poolCategories.length === 0
+  ) {
     return <></>
   }
 
@@ -186,6 +228,12 @@ export function FilterTags() {
           <TagCloseButton onClick={() => setMinTvl(0)} />
         </Tag>
       )}
+      {poolCategories.map(poolCategory => (
+        <Tag key={poolCategory} size="lg">
+          <TagLabel>{poolCategoryLabel(poolCategory)}</TagLabel>
+          <TagCloseButton onClick={() => togglePoolCategory(false, poolCategory)} />
+        </Tag>
+      ))}
     </HStack>
   )
 }
@@ -235,6 +283,11 @@ export function PoolListFilters() {
                       <Divider />
                     </>
                   )}
+                  <Heading as="h3" size="sm" mb="1.5">
+                    Staking rewards
+                  </Heading>
+                  <PoolCategoryFilters />
+                  <Divider />
                   <Heading as="h3" size="sm" mb="1.5">
                     Pool types
                   </Heading>

--- a/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -5,12 +5,14 @@ import {
   GqlPoolType,
   GqlPoolOrderBy,
   GqlPoolOrderDirection,
+  GqlPoolFilterCategory,
 } from '@/lib/shared/services/api/generated/graphql'
 import { uniq } from 'lodash'
 import { getProjectConfig } from '@/lib/config/getProjectConfig'
 import { useQueryState } from 'next-usequerystate'
 import {
   POOL_TYPE_MAP,
+  PoolCategoryType,
   PoolFilterType,
   poolListQueryStateParsers,
   SortingState,
@@ -21,16 +23,20 @@ export function usePoolListQueryState() {
   const [first, setFirst] = useQueryState('first', poolListQueryStateParsers.first)
   const [skip, setSkip] = useQueryState('skip', poolListQueryStateParsers.skip)
   const [orderBy, setOrderBy] = useQueryState('orderBy', poolListQueryStateParsers.orderBy)
+
   const [orderDirection, setOrderDirection] = useQueryState(
     'orderDirection',
     poolListQueryStateParsers.orderDirection
   )
+
   const [poolTypes, setPoolTypes] = useQueryState('poolTypes', poolListQueryStateParsers.poolTypes)
   const [networks, setNetworks] = useQueryState('networks', poolListQueryStateParsers.networks)
+
   const [textSearch, setTextSearch] = useQueryState(
     'textSearch',
     poolListQueryStateParsers.textSearch
   )
+
   const [userAddress, setUserAddress] = useQueryState(
     'userAddress',
     poolListQueryStateParsers.userAddress
@@ -38,12 +44,26 @@ export function usePoolListQueryState() {
 
   const [minTvl, setMinTvl] = useQueryState('minTvl', poolListQueryStateParsers.minTvl)
 
+  const [poolCategories, setPoolCategories] = useQueryState(
+    'poolCategories',
+    poolListQueryStateParsers.poolCategories
+  )
+
   // Set internal checked state
   function toggleUserAddress(checked: boolean, address: string) {
     if (checked) {
       setUserAddress(address)
     } else {
       setUserAddress('')
+    }
+  }
+
+  // Set internal checked state
+  function togglePoolCategory(checked: boolean, poolCategory: PoolCategoryType) {
+    if (checked) {
+      setPoolCategories(current => uniq([...current, poolCategory]))
+    } else {
+      setPoolCategories(current => current.filter(item => item !== poolCategory))
     }
   }
 
@@ -87,7 +107,6 @@ export function usePoolListQueryState() {
     if (text.length > 0) {
       setSkip(0)
     }
-
     setTextSearch(text)
   }
 
@@ -106,8 +125,22 @@ export function usePoolListQueryState() {
     }
   }
 
+  function poolCategoryLabel(poolCategory: GqlPoolFilterCategory) {
+    switch (poolCategory) {
+      case GqlPoolFilterCategory.BlackListed:
+        return 'Blacklisted'
+      case GqlPoolFilterCategory.Incentivized:
+        return 'Incentivized'
+    }
+  }
+
   const totalFilterCount =
-    networks.length + poolTypes.length + (userAddress ? 1 : 0) + (minTvl > 0 ? 1 : 0)
+    networks.length +
+    poolTypes.length +
+    (userAddress ? 1 : 0) +
+    (minTvl > 0 ? 1 : 0) +
+    poolCategories.length
+
   const sorting: SortingState = orderBy
     ? [{ id: orderBy, desc: orderDirection === GqlPoolOrderDirection.Desc }]
     : []
@@ -133,6 +166,7 @@ export function usePoolListQueryState() {
       chainIn: networks.length > 0 ? networks : getProjectConfig().supportedNetworks,
       userAddress,
       minTvl,
+      categoryIn: poolCategories.length > 0 ? poolCategories : null,
     },
     textSearch,
   }
@@ -150,11 +184,16 @@ export function usePoolListQueryState() {
     toggleUserAddress,
     toggleNetwork,
     togglePoolType,
+    togglePoolCategory,
     poolTypeLabel,
+    poolCategoryLabel,
     setSorting,
     setPagination,
     setSearch,
     setMinTvl,
+    setPoolTypes,
+    setPoolCategories,
+    poolCategories,
     minTvl,
     searchText: textSearch,
     pagination,

--- a/lib/modules/pool/pool.types.ts
+++ b/lib/modules/pool/pool.types.ts
@@ -5,6 +5,7 @@ import {
   GqlPoolType,
   GqlPoolOrderBy,
   GqlPoolOrderDirection,
+  GqlPoolFilterCategory,
 } from '@/lib/shared/services/api/generated/graphql'
 import {
   parseAsArrayOf,
@@ -65,6 +66,13 @@ export const poolTypeFilters = [
 
 export type PoolFilterType = (typeof poolTypeFilters)[number]
 
+export const poolCategoryFilters = [
+  //GqlPoolFilterCategory.BlackListed, NOT USED
+  GqlPoolFilterCategory.Incentivized,
+] as const
+
+export type PoolCategoryType = (typeof poolCategoryFilters)[number]
+
 export type SortingState = PoolsColumnSort[]
 
 // We need to map toggalable pool types to their corresponding set of GqlPoolTypes.
@@ -105,4 +113,7 @@ export const poolListQueryStateParsers = {
   textSearch: parseAsString,
   userAddress: parseAsString,
   minTvl: parseAsFloat.withDefault(0),
+  poolCategories: parseAsArrayOf(
+    parseAsStringEnum<PoolCategoryType>(Object.values(poolCategoryFilters))
+  ).withDefault([]),
 }

--- a/lib/modules/pool/pool.utils.ts
+++ b/lib/modules/pool/pool.utils.ts
@@ -7,6 +7,7 @@ import {
   GqlPoolTokenDetail,
   GqlPoolType,
   GqlBalancePoolAprSubItem,
+  GqlPoolFilterCategory,
 } from '@/lib/shared/services/api/generated/graphql'
 import { invert } from 'lodash'
 import { FetchPoolProps, PoolAction, PoolListItem, PoolVariant } from './pool.types'
@@ -150,6 +151,16 @@ const poolTypeLabelMap: { [key in GqlPoolType]: string } = {
 
 export function getPoolTypeLabel(type: GqlPoolType): string {
   return poolTypeLabelMap[type] ?? type.replace(/_/g, ' ').toLowerCase()
+}
+
+// Maps GraphQL pool category enum to human readable label for UI.
+const poolCategoryLabelMap: { [key in GqlPoolFilterCategory]: string } = {
+  [GqlPoolFilterCategory.BlackListed]: 'Blacklisted',
+  [GqlPoolFilterCategory.Incentivized]: 'Incentivized',
+}
+
+export function getPoolCategoryLabel(category: GqlPoolFilterCategory): string {
+  return poolCategoryLabelMap[category] ?? category.replace(/_/g, ' ').toLowerCase()
 }
 
 export const poolClickHandler = (


### PR DESCRIPTION
fixes #481 

- add pool category filter (currently only has `INCENTIVIZED` as an option)
- remove query params in url when empty (for types & categories)

![image](https://github.com/balancer/frontend-v3/assets/20125808/a2863326-7dac-404a-953e-510d994d6ea4)

![image](https://github.com/balancer/frontend-v3/assets/20125808/bb26b80c-af96-4ad0-b0e6-0afde32ad358)

