### PR TITLE
fix: add global mocks to always use test rpc urls in test execution

### DIFF
--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -59,7 +59,7 @@ export const chains: readonly [Chain, ...Chain[]] = [
     .map(gqlChain => gqlChainToWagmiChainMap[gqlChain]),
 ]
 
-const chainsByKey = keyBy(chains, 'id')
+export const chainsByKey = keyBy(chains, 'id')
 export function getDefaultRpcUrl(chainId: number) {
   return chainsByKey[chainId].rpcUrls.default.http[0]
 }

--- a/test/anvil/anvil-setup.ts
+++ b/test/anvil/anvil-setup.ts
@@ -1,6 +1,3 @@
-import { getChainId } from '@/lib/config/app.config'
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
-import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet, polygon } from 'viem/chains'
@@ -31,7 +28,7 @@ const ANVIL_PORTS: Record<NetworksWithFork, number> = {
 export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
   Ethereum: {
     networkName: 'Ethereum',
-    fallBackRpc: getDefaultRpcUrl(getChainId(GqlChain.Mainnet)),
+    fallBackRpc: 'https://cloudflare-eth.com',
     port: ANVIL_PORTS.Ethereum,
     // From time to time this block gets outdated having this kind of error in integration tests:
     // ContractFunctionExecutionError: The contract function "queryJoin" returned no data ("0x").
@@ -39,7 +36,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
   },
   Polygon: {
     networkName: 'Polygon',
-    fallBackRpc: getDefaultRpcUrl(getChainId(GqlChain.Polygon)),
+    fallBackRpc: 'https://polygon-rpc.com',
     port: ANVIL_PORTS.Polygon,
     // Note - this has to be >= highest blockNo used in tests
     forkBlockNumber: 44215395n,

--- a/test/vitest/setup-integration.ts
+++ b/test/vitest/setup-integration.ts
@@ -1,4 +1,9 @@
 import { connectWithDefaultUser, disconnectDefaultUser } from '../utils/wagmi/wagmi-connections'
+import * as chainConfigModule from '../../lib/modules/web3/ChainConfig'
+import { NetworksWithFork, getTestRpcSetup } from '../anvil/anvil-setup'
+import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
+import { createPublicClient, http } from 'viem'
+import { mainnetTest, polygonTest } from '../anvil/testWagmiConfig'
 
 /*
   Specific setup for integration tests (that it is not needed in unit tests)
@@ -11,4 +16,36 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await disconnectDefaultUser()
+})
+
+/*
+  Mocks getDefaultRpcUrl to return the test rpcUrl ('http://127.0.0.1:port/poolId')
+  Keeps the rest of the module unmocked
+*/
+vi.mock('../../lib/modules/web3/ChainConfig', async importOriginal => {
+  const originalModule = await importOriginal<typeof chainConfigModule>()
+  return {
+    ...originalModule,
+    getDefaultRpcUrl: (chainId: number) => {
+      const { rpcUrl } = getTestRpcSetup(
+        chainConfigModule.chainsByKey[chainId].name as NetworksWithFork
+      )
+      return rpcUrl
+    },
+  }
+})
+
+/*
+  Mocks getViemClient to use the test chain definitions,
+  which use test rpcUrls ('http://127.0.0.1:port/poolId')
+*/
+vi.mock('../../lib/shared/services/viem/viem.client', () => {
+  return {
+    getViemClient: (chain: GqlChain) => {
+      return createPublicClient({
+        chain: chain === GqlChain.Mainnet ? mainnetTest : polygonTest,
+        transport: http(),
+      })
+    },
+  }
 })


### PR DESCRIPTION
This change prevents rate-limit errors in test execution.