### PR TITLE
fix: add vaultVersion to all pool mocks

### DIFF
--- a/lib/modules/pool/__mocks__/gyroPoolMock.ts
+++ b/lib/modules/pool/__mocks__/gyroPoolMock.ts
@@ -7,6 +7,7 @@ export const gyroPoolMock: GqlPoolElement = {
   address: '0xdac42eeb17758daa38caf9a3540c808247527ae3',
   name: 'Gyroscope 2-CLP USDC/DAI',
   version: 1,
+  vaultVersion: 2,
   owner: '0x0000000000000000000000000000000000000000',
   decimals: 18,
   factory: '0x5d8545a7330245150be0ce88f8afb0edc41dfc34',

--- a/test/msw/builders/gqlPoolElement.builders.ts
+++ b/test/msw/builders/gqlPoolElement.builders.ts
@@ -35,6 +35,7 @@ export function aBalWethPoolElementMock(...options: Partial<GqlPoolElement>[]): 
     address: getPoolAddress(poolId),
     allTokens,
     poolTokens: tokens as unknown as GqlPoolTokenDetail[],
+    vaultVersion: 2,
     ...options,
   }
 
@@ -52,6 +53,7 @@ export function aWjAuraWethPoolElementMock(...options: Partial<GqlPoolElement>[]
     address: getPoolAddress(poolId),
     allTokens: tokens,
     poolTokens: tokens as unknown as GqlPoolTokenDetail[],
+    vaultVersion: 2,
     ...options,
   }
 
@@ -185,5 +187,6 @@ export function aPhantomStablePoolMock(): GqlPoolElement {
     poolTokens: tokens as unknown as GqlPoolTokenDetail[],
     allTokens: tokens as unknown as GqlPoolTokenExpanded[],
     type: GqlPoolType.ComposableStable,
+    vaultVersion: 2,
   })
 }


### PR DESCRIPTION
[This commit](https://github.com/balancer/frontend-v3/pull/635/commits/4832c724ab7e770cbd4e1bd49f2cfdef8c5017de) was breaking most of the handler integration tests because the pool mocks did not have `vaultVersion`.