### PR TITLE
fix: condition to only complete token approval when it is >0

### DIFF
--- a/lib/modules/swap/modal/SwapModalBody.tsx
+++ b/lib/modules/swap/modal/SwapModalBody.tsx
@@ -10,23 +10,23 @@ export function SwapModalBody() {
   // Wrap and unwrap receipts will not have slippage so we don't need a receipt for them
   if (swapTxHash && !isWrap) {
     return (
-      <MotionDiv key="receipt">
+      <MotionDiv id="receipt">
         <SwapReceipt txHash={swapTxHash} />
       </MotionDiv>
     )
   }
 
   return (
-    <MotionDiv key="preview">
+    <MotionDiv id="preview">
       <SwapPreview />
     </MotionDiv>
   )
 }
 
-function MotionDiv({ key, children }: PropsWithChildren<{ key: string }>) {
+function MotionDiv({ id, children }: PropsWithChildren<{ id: string }>) {
   return (
     <motion.div
-      key={key}
+      key={id}
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}

--- a/lib/modules/tokens/approvals/approval-labels.spec.ts
+++ b/lib/modules/tokens/approvals/approval-labels.spec.ts
@@ -1,7 +1,11 @@
 import { TokenApprovalLabelArgs, buildTokenApprovalLabels } from './approval-labels'
 
 test('Token approval labels for add liquidity', () => {
-  const args: TokenApprovalLabelArgs = { actionType: 'AddLiquidity', symbol: 'WETH' }
+  const args: TokenApprovalLabelArgs = {
+    actionType: 'AddLiquidity',
+    symbol: 'WETH',
+    requiredRawAmount: 100000000n,
+  }
   const result = buildTokenApprovalLabels(args)
   expect(result).toMatchInlineSnapshot(`
     {
@@ -17,8 +21,22 @@ test('Token approval labels for add liquidity', () => {
   `)
 })
 
+test('Token approval title when approving 0 USDT', () => {
+  const args: TokenApprovalLabelArgs = {
+    actionType: 'AddLiquidity',
+    symbol: 'WETH',
+    requiredRawAmount: 0n,
+  }
+  const result = buildTokenApprovalLabels(args)
+  expect(result.title).toBe('Approve 0 WETH')
+})
+
 test('Token approval labels for unapprove', () => {
-  const args: TokenApprovalLabelArgs = { actionType: 'Unapprove', symbol: 'WETH' }
+  const args: TokenApprovalLabelArgs = {
+    actionType: 'Unapprove',
+    symbol: 'WETH',
+    requiredRawAmount: 100000000n,
+  }
   const result = buildTokenApprovalLabels(args)
   expect(result).toMatchInlineSnapshot(`
     {

--- a/lib/modules/tokens/approvals/approval-labels.ts
+++ b/lib/modules/tokens/approvals/approval-labels.ts
@@ -11,20 +11,23 @@ export type ApprovalAction =
 export type TokenApprovalLabelArgs = {
   actionType: ApprovalAction
   symbol: string
+  requiredRawAmount: bigint
 }
 
-export const buildTokenApprovalLabels: BuildTransactionLabels = (args: TokenApprovalLabelArgs) => {
+export const buildTokenApprovalLabels: BuildTransactionLabels = ({
+  requiredRawAmount,
+  actionType,
+  symbol,
+}: TokenApprovalLabelArgs) => {
   return {
-    init: initApprovalLabelFor(args.actionType, args.symbol),
-    title: `Approve ${args.symbol}`,
-    description: descriptionFor(args.actionType, args.symbol),
-    confirming:
-      args.actionType === 'Unapprove'
-        ? `Unapproving ${args.symbol}...`
-        : `Approving ${args.symbol}...`,
-    confirmed: `${args.symbol} ${args.actionType === 'Unapprove' ? 'unapproved' : 'approved!'}`,
-    tooltip: tooltipApprovalLabelFor(args.actionType, args.symbol),
-    error: `Error ${args.actionType === 'Unapprove' ? 'unapproving' : 'approving'} ${args.symbol}`,
+    init: initApprovalLabelFor(actionType, symbol),
+    // requiredRawAmount === 0n is an edge-case for tokens like USDT
+    title: requiredRawAmount > 0n ? `Approve ${symbol}` : `Approve 0 ${symbol}`,
+    description: descriptionFor(actionType, symbol),
+    confirming: actionType === 'Unapprove' ? `Unapproving ${symbol}...` : `Approving ${symbol}...`,
+    confirmed: `${symbol} ${actionType === 'Unapprove' ? 'unapproved' : 'approved!'}`,
+    tooltip: tooltipApprovalLabelFor(actionType, symbol),
+    error: `Error ${actionType === 'Unapprove' ? 'unapproving' : 'approving'} ${symbol}`,
   }
 }
 

--- a/lib/modules/tokens/approvals/approval-rules.spec.ts
+++ b/lib/modules/tokens/approvals/approval-rules.spec.ts
@@ -2,7 +2,6 @@ import { SupportedChainId } from '@/lib/config/config.types'
 import { usdtAddress, wETHAddress, wjAuraAddress } from '@/lib/debug-helpers'
 import { MAX_BIGINT } from '@/lib/shared/utils/numbers'
 import { testRawAmount } from '@/test/utils/numbers'
-import { Address } from 'viem'
 import { RawAmount, getRequiredTokenApprovals } from './approval-rules'
 
 const chainId: SupportedChainId = 1
@@ -14,7 +13,7 @@ const rawAmounts: RawAmount[] = [
   },
   {
     address: wjAuraAddress,
-    rawAmount: testRawAmount('10'),
+    rawAmount: testRawAmount('20'),
   },
 ]
 
@@ -44,25 +43,10 @@ describe('getRequiredTokenApprovals', () => {
     ).toEqual([])
   })
 
-  test.skip('when all token allowances are lesser than the amounts to approve', () => {
+  test('when all the amounts to approve are greater than zero', () => {
     expect(
       getRequiredTokenApprovals({
-        rawAmounts: rawAmounts,
-        chainId,
-        allowanceFor,
-      })
-    ).toEqual([])
-  })
-
-  test.skip('when some token allowances are greater than the amounts to approve', () => {
-    function allowanceFor(tokenAddress: Address): bigint {
-      if (tokenAddress === wETHAddress) return 5n
-      return MAX_BIGINT
-    }
-
-    expect(
-      getRequiredTokenApprovals({
-        rawAmounts: rawAmounts,
+        rawAmounts,
         chainId,
         allowanceFor,
       })
@@ -72,11 +56,11 @@ describe('getRequiredTokenApprovals', () => {
         requiredRawAmount: 10000000000000000000n,
         requestedRawAmount: MAX_BIGINT,
       },
-      // {
-      //   tokenAddress: wjAuraAddress,
-      //   requiredRawAmount: 10000000000000000000n,
-      //   requestedRawAmount: MAX_BIGINT,
-      // },
+      {
+        tokenAddress: wjAuraAddress,
+        requiredRawAmount: 20000000000000000000n,
+        requestedRawAmount: MAX_BIGINT,
+      },
     ])
   })
 

--- a/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -13,6 +13,7 @@ import { useUserAccount } from '../../web3/UserAccountProvider'
 import { useTokens } from '../TokensProvider'
 import { ApprovalAction, buildTokenApprovalLabels } from './approval-labels'
 import { RawAmount, getRequiredTokenApprovals } from './approval-rules'
+import { requiresDoubleApproval } from '../token.helpers'
 
 export type Params = {
   spenderAddress: Address
@@ -64,10 +65,15 @@ export function useTokenApprovalSteps({
       const { tokenAddress, requiredRawAmount, requestedRawAmount } = tokenAmountToApprove
       const token = getToken(tokenAddress, chain)
       const symbol = bptSymbol ?? (token && token?.symbol) ?? 'Unknown'
-      const labels = buildTokenApprovalLabels({ actionType, symbol })
+      const labels = buildTokenApprovalLabels({ actionType, symbol, requiredRawAmount })
       const id = tokenAddress
 
-      const isComplete = () => tokenAllowances.allowanceFor(tokenAddress) >= requiredRawAmount
+      const isComplete = () => {
+        const isAllowed = tokenAllowances.allowanceFor(tokenAddress) >= requiredRawAmount
+        // USDT edge-case: requires setting approval to 0n before adjusting the value up again
+        if (requiresDoubleApproval(chain, tokenAddress)) return isAllowed
+        return requiredRawAmount > 0n && isAllowed
+      }
 
       const props: ManagedErc20TransactionInput = {
         tokenAddress,

--- a/lib/modules/transactions/transaction-steps/step-tracker/Steps.tsx
+++ b/lib/modules/transactions/transaction-steps/step-tracker/Steps.tsx
@@ -15,7 +15,7 @@ export function Steps({ transactionSteps }: Props) {
     <VStack align="start" spacing="xs">
       {steps &&
         steps.map((step, index) => (
-          <div key={step.id}>
+          <div key={step.id + index}>
             <Step
               currentIndex={currentStepIndex}
               index={index}


### PR DESCRIPTION
Fix [this token approval state error reported in discord](https://discord.com/channels/638460494168064021/1240619343306293309/1250929740811079801).

Also improves step titles for USDT double approval edge-case and fixes some problems related with unique keys and indexes.
 