### PR TITLE
fix: use proper chain id when looking for recent transactions

### DIFF
--- a/lib/modules/transactions/RecentTransactionsProvider.tsx
+++ b/lib/modules/transactions/RecentTransactionsProvider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { getChainId } from '@/lib/config/app.config'
 import { Toast } from '@/lib/shared/components/toasts/Toast'
 import { getBlockExplorerTxUrl } from '@/lib/shared/hooks/useBlockExplorer'
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
@@ -40,7 +41,7 @@ export type TrackedTransaction = {
   toastId?: ToastId
   timestamp: number
   init?: string
-  chain?: GqlChain
+  chain: GqlChain
   duration?: number | null
   poolId?: string
 }
@@ -81,7 +82,10 @@ export function _useRecentTransactions() {
       // so we use the underlying viem call to get the transactions confirmation status
       for (const tx of unconfirmedTransactions) {
         try {
-          const receipt = await waitForTransactionReceipt(config, { hash: tx.hash })
+          const receipt = await waitForTransactionReceipt(config, {
+            hash: tx.hash,
+            chainId: getChainId(tx.chain),
+          })
           if (receipt?.status === 'success') {
             updatePayload[tx.hash] = {
               ...tx,

--- a/lib/modules/web3/contracts/useOnTransactionSubmission.ts
+++ b/lib/modules/web3/contracts/useOnTransactionSubmission.ts
@@ -6,8 +6,8 @@ import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 
 type NewTrackedTransactionRequest = {
   labels: TransactionLabels
+  chain: GqlChain
   hash?: Address
-  chain?: GqlChain
 }
 
 export function useOnTransactionSubmission({ labels, hash, chain }: NewTrackedTransactionRequest) {


### PR DESCRIPTION
- Change TS to require `chain` in localStorage transactions
- Uses the stored `chain` to query recent transactions. 

Fixes issue where recent transaction query was loading forever: 


https://github.com/balancer/frontend-v3/assets/1316240/5e23175a-82c8-4439-8bca-9d7b7e03c3a6

