### PR TITLE
fix: reset current step index on Add Liquidity modal open

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
@@ -41,6 +41,13 @@ export function AddLiquidityModal({
   const isMounted = useIsMounted()
   const { userAddress } = useUserAccount()
 
+  // Every time the modal is opened, reset the current step index to re-check isCompleted for all steps
+  // (conditions might have changed, for instance, for token approvals)
+  useEffect(() => {
+    if (isOpen) transactionSteps.setCurrentStepIndex(0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
   useEffect(() => {
     if (addLiquidityTxHash && !window.location.pathname.includes(addLiquidityTxHash)) {
       window.history.replaceState({}, '', `./add-liquidity/${addLiquidityTxHash}`)


### PR DESCRIPTION
Several testoors registered issues when a token has smaller approval than required. This fix could fix some of those but maybe not all of them. 

Examples:
https://discord.com/channels/638460494168064021/1257872445537390713/1258016852831895603 
https://discord.com/channels/638460494168064021/1258400078792757279/1258400081661399182

**Fixed scenario:** 
- I have allowance for `2 GHO` and `18 AaveUSDCn`
- I try to add 2 GHO (and the proportional AaveUSDCn) and the modal shows that the approval steps are completed
- If I go back, change the input to `3 GHO` and open the modal again. The steps are shown as completed when they shouldn't, which triggers a tx simulation error (join with not enough allowance error).

**Before fix**
 
https://github.com/balancer/frontend-v3/assets/1316240/5cb85016-777f-4c70-8b64-8a1e43612b98

**After fix:** 

The approval steps now show the correct state cause `isCompleted` is rechecked when the modal re-opens.

https://github.com/balancer/frontend-v3/assets/1316240/7c09cb5f-0088-4923-a1eb-faa79847d96b





