### PR TITLE
fix: reset current step index on flow modal open

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
@@ -18,6 +18,7 @@ import { usePoolRedirect } from '../../../pool.hooks'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
+import { useResetStepIndexOnOpen } from '../../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -41,12 +42,7 @@ export function AddLiquidityModal({
   const isMounted = useIsMounted()
   const { userAddress } = useUserAccount()
 
-  // Every time the modal is opened, reset the current step index to re-check isCompleted for all steps
-  // (conditions might have changed, for instance, for token approvals)
-  useEffect(() => {
-    if (isOpen) transactionSteps.setCurrentStepIndex(0)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   useEffect(() => {
     if (addLiquidityTxHash && !window.location.pathname.includes(addLiquidityTxHash)) {

--- a/lib/modules/pool/actions/claim/ClaimModal.tsx
+++ b/lib/modules/pool/actions/claim/ClaimModal.tsx
@@ -23,6 +23,7 @@ import { SuccessOverlay } from '@/lib/shared/components/modals/SuccessOverlay'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
 import { useEffect, useMemo, useState } from 'react'
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
+import { useResetStepIndexOnOpen } from '../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -41,6 +42,8 @@ export function ClaimModal({
 
   const { isDesktop, isMobile } = useBreakpoints()
   const { transactionSteps, claimTxHash, allClaimableRewards, totalClaimableUsd } = useClaim()
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   const rewards = useMemo(
     () =>

--- a/lib/modules/pool/actions/migrateStake/MigrateStakeModal.tsx
+++ b/lib/modules/pool/actions/migrateStake/MigrateStakeModal.tsx
@@ -21,6 +21,7 @@ import { MigrateStakePreview } from './MigrateStakePreview'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
 import { ActionModalFooter } from '@/lib/shared/components/modals/ActionModalFooter'
 import { usePoolRedirect } from '../../pool.hooks'
+import { useResetStepIndexOnOpen } from '../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -41,6 +42,8 @@ export function MigrateStakeModal({
   const { pool } = usePool()
   const { isMobile } = useBreakpoints()
   const { redirectToPoolPage } = usePoolRedirect(pool)
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   return (
     <Modal

--- a/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
@@ -18,6 +18,7 @@ import { usePoolRedirect } from '../../../pool.hooks'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
+import { useResetStepIndexOnOpen } from '../../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -39,6 +40,8 @@ export function RemoveLiquidityModal({
   const { redirectToPoolPage } = usePoolRedirect(pool)
   const { userAddress } = useUserAccount()
   const isMounted = useIsMounted()
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   useEffect(() => {
     if (removeLiquidityTxHash && !window.location.pathname.includes(removeLiquidityTxHash)) {

--- a/lib/modules/pool/actions/stake/StakeModal.tsx
+++ b/lib/modules/pool/actions/stake/StakeModal.tsx
@@ -21,6 +21,7 @@ import { MobileStepTracker } from '@/lib/modules/transactions/transaction-steps/
 import { ActionModalFooter } from '@/lib/shared/components/modals/ActionModalFooter'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
 import { usePoolRedirect } from '../../pool.hooks'
+import { useResetStepIndexOnOpen } from '../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -41,6 +42,8 @@ export function StakeModal({
   const { pool } = usePool()
   const { redirectToPoolPage } = usePoolRedirect(pool)
   const { isMobile } = useBreakpoints()
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   return (
     <Modal

--- a/lib/modules/pool/actions/unstake/UnstakeModal.tsx
+++ b/lib/modules/pool/actions/unstake/UnstakeModal.tsx
@@ -21,6 +21,7 @@ import { UnstakePreview } from './UnstakePreview'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
 import { ActionModalFooter } from '@/lib/shared/components/modals/ActionModalFooter'
 import { usePoolRedirect } from '../../pool.hooks'
+import { useResetStepIndexOnOpen } from '../useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -41,6 +42,8 @@ export function UnstakeModal({
   const { pool } = usePool()
   const { isMobile } = useBreakpoints()
   const { redirectToPoolPage } = usePoolRedirect(pool)
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   return (
     <Modal

--- a/lib/modules/pool/actions/useResetStepIndexOnOpen.tsx
+++ b/lib/modules/pool/actions/useResetStepIndexOnOpen.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { TransactionStepsResponse } from '../../transactions/transaction-steps/useTransactionSteps'
+
+/*
+  Used by flow modals:
+  Every time the modal is opened, reset the current step index to re-check isCompleted for all steps
+ (conditions might have changed, for instance, for token approvals)
+ */
+export function useResetStepIndexOnOpen(
+  isOpen: boolean,
+  transactionSteps: TransactionStepsResponse
+) {
+  useEffect(() => {
+    if (isOpen) transactionSteps.setCurrentStepIndex(0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+}

--- a/lib/modules/swap/modal/SwapModal.tsx
+++ b/lib/modules/swap/modal/SwapModal.tsx
@@ -17,6 +17,7 @@ import { SwapModalBody } from './SwapModalBody'
 import { SuccessOverlay } from '@/lib/shared/components/modals/SuccessOverlay'
 import { useUserAccount } from '../../web3/UserAccountProvider'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
+import { useResetStepIndexOnOpen } from '../../pool/actions/useResetStepIndexOnOpen'
 
 type Props = {
   isOpen: boolean
@@ -38,6 +39,8 @@ export function SwapPreviewModal({
 
   const { transactionSteps, swapAction, isWrap, selectedChain, swapTxHash, hasQuoteContext } =
     useSwap()
+
+  useResetStepIndexOnOpen(isOpen, transactionSteps)
 
   useEffect(() => {
     if (!isWrap && swapTxHash && !window.location.pathname.includes(swapTxHash)) {


### PR DESCRIPTION
Extract a shared hook to apply [this fix ](https://github.com/balancer/frontend-v3/pull/738) in all flow modals. 