### PR TITLE
fix: avoid swap simulations with zero swapAmount

### DIFF
--- a/lib/modules/swap/queries/useSimulateSwapQuery.ts
+++ b/lib/modules/swap/queries/useSimulateSwapQuery.ts
@@ -39,7 +39,7 @@ export function useSimulateSwapQuery({
   return useQuery<SimulateSwapResponse, Error>({
     queryKey,
     queryFn,
-    enabled: enabled && !!isZero(debouncedSwapAmount),
+    enabled: enabled && !isZero(debouncedSwapAmount),
     gcTime: 0,
     meta: sentryMetaForSwapHandler('Error in swap simulation query', {
       handler,


### PR DESCRIPTION
Avoid calling swap simulations when `swapAmount` is zero. This was causing a division by zero in the simulation call like [this sentry error shows](https://balancer-labs.sentry.io/issues/5576083906/?alert_rule_id=15206571&alert_type=issue&notification_uuid=4f974937-24ef-4550-a8aa-ec476ffab248&project=4506382607712256&referrer=slack).