### PR TITLE
fix: avoid buildCall when user account is empty

### DIFF
--- a/lib/modules/swap/useSwapStep.tsx
+++ b/lib/modules/swap/useSwapStep.tsx
@@ -14,6 +14,7 @@ import { BuildSwapQueryParams, useBuildSwapQuery } from './queries/useBuildSwapQ
 import { swapActionPastTense } from './swap.helpers'
 import { SwapAction } from './swap.types'
 import { useTokenBalances } from '../tokens/TokenBalancesProvider'
+import { useUserAccount } from '../web3/UserAccountProvider'
 
 export const swapStepId = 'swap'
 
@@ -32,6 +33,7 @@ export function useSwapStep({
   tokenInInfo,
   tokenOutInfo,
 }: SwapStepParams): TransactionStep {
+  const { isConnected } = useUserAccount()
   const [isBuildQueryEnabled, setIsBuildQueryEnabled] = useState(false)
   const { getTransaction } = useTransactionState()
   const { refetchBalances } = useTokenBalances()
@@ -58,7 +60,7 @@ export function useSwapStep({
 
   useEffect(() => {
     // simulationQuery is refetched every 30 seconds by SwapTimeout
-    if (simulationQuery.data) {
+    if (simulationQuery.data && isConnected) {
       buildSwapQuery.refetch()
     }
   }, [simulationQuery.data])


### PR DESCRIPTION
Avoids calling` swap.buildCall` when the user was not connected (`userAddress === ''`).

`refetch` ignores `enabled` condition so we needed an explicit `isConnected`

Solves this [sentry error](https://balancer-labs.sentry.io/issues/5584759813/?alert_rule_id=15206571&alert_type=issue&notification_uuid=fc28384a-1ddb-4dca-ae33-d981b66ed40f&project=4506382607712256&referrer=slack) 




