### PR TITLE
chore: change default rpc url for mainnet

### DIFF
--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -41,6 +41,11 @@ export const rpcFallbacks: Record<GqlChain, string | undefined> = {
 
 // Helpful for injecting fork RPCs for specific chains.
 export const rpcOverrides: Record<GqlChain, string | undefined> = {
+  /*
+    Using alternative rpc url as the default one (cloudflare-eth.com) is leading to 429 rate limit issues:
+    1. Lower request limit
+    2. 429s are difficult to handle (due to CORS): https://community.cloudflare.com/t/cors-on-rate-limit-429/270010/11
+  */
   [GqlChain.Mainnet]: 'https://ethereum-rpc.publicnode.com',
   [GqlChain.Arbitrum]: undefined,
   [GqlChain.Base]: undefined,


### PR DESCRIPTION
`ethereum-rpc.publicnode.com` allows more requests than `cloudflare-eth.com` before getting a 429 (Too many requests) error.

Also, with `cloudflare-eth.com`[ it is difficult to handle 429 properly](https://community.cloudflare.com/t/cors-on-rate-limit-429/270010/11). Let's see if `ethereum-rpc.publicnode.com` handles 429 errors better so that we catch them in sentry.