### PR TITLE
chore: change default token price to avoid race condition error

### DIFF
--- a/lib/modules/tokens/__mocks__/token.builders.ts
+++ b/lib/modules/tokens/__mocks__/token.builders.ts
@@ -114,7 +114,7 @@ export function aTokenPriceMock(...options: Partial<GqlTokenPrice>[]): GqlTokenP
     __typename: 'GqlTokenPrice',
     address: emptyAddress,
     chain: GqlChain.Mainnet,
-    price: 10,
+    price: 2,
     updatedAt: 1,
   }
   return Object.assign({}, defaultPrice, ...options)


### PR DESCRIPTION
We had a flaky unit test in `RemoveLiquidityProvider.spec.tsx`. This should help avoid it until we have more time to investigate.