### PR TITLE
fix: avoid warning while loading RainbowKit customTheme

### DIFF
--- a/lib/modules/web3/Web3Provider.tsx
+++ b/lib/modules/web3/Web3Provider.tsx
@@ -14,14 +14,23 @@ import { CustomAvatar } from './CustomAvatar'
 import { UserAccountProvider } from './UserAccountProvider'
 import { PropsWithChildren } from 'react'
 import { WagmiConfig } from './WagmiConfig'
+import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
 
 export function Web3Provider({
   children,
   wagmiConfig,
 }: PropsWithChildren<{ wagmiConfig: WagmiConfig }>) {
+  const isMounted = useIsMounted()
+
   const { colors, radii, shadows, semanticTokens, fonts } = useTheme()
   const colorMode = useThemeColorMode()
   const colorModeKey = colorMode === 'light' ? 'default' : '_dark'
+
+  /*
+    Avoids warning (Warning: Prop `dangerouslySetInnerHTML` did not match. Server...)
+    when customTheme changes from default (dark) to light theme while mounting.
+  */
+  if (!isMounted) return null
 
   const sharedConfig = {
     fonts: {


### PR DESCRIPTION
Loading the app in light mode was throwing this warning: 

<img width="1916" alt="Screenshot 2024-07-16 at 14 35 10" src="https://github.com/user-attachments/assets/cb863715-9b07-40fd-b5e2-77207e436e05">
