### PR TITLE
fix: show full swap error description

### DIFF
--- a/lib/shared/components/errors/ErrorAlert.tsx
+++ b/lib/shared/components/errors/ErrorAlert.tsx
@@ -12,7 +12,7 @@ export function ErrorAlert({ title, children, ...rest }: Props) {
   return (
     <Alert rounded="md" status="error" mb="0" {...rest}>
       <Icon as={XCircle} color="red.500" boxSize="1.5em" />
-      <Box ml="md" overflow="hidden">
+      <Box ml="md" maxHeight="160" overflowY="auto" paddingRight="2">
         <AlertTitle>{title}</AlertTitle>
         <AlertDescription>{children}</AlertDescription>
       </Box>


### PR DESCRIPTION
Quick fix until we implement a better error component (for example truncating text + copy paste button feature).

**Before**: 

![screenshot_2024-07-16_at_18 03 29_720](https://github.com/user-attachments/assets/5348e379-3af3-4fdc-ab06-38dad9282810)

**After**:

<img width="639" alt="Screenshot 2024-07-17 at 09 58 28" src="https://github.com/user-attachments/assets/0f15b974-09f7-43f4-a572-8e252583f7cd">

