### PR TITLE
fix: Animation jank in modals

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -231,12 +231,7 @@ function AddLiquidityMainForm() {
           )}
         </VStack>
       </Card>
-      <AddLiquidityModal
-        finalFocusRef={nextBtn}
-        isOpen={previewModalDisclosure.isOpen}
-        onOpen={previewModalDisclosure.onOpen}
-        onClose={previewModalDisclosure.onClose}
-      />
+      <AddLiquidityModal finalFocusRef={nextBtn} />
       {!!validTokens.length && (
         <NativeAssetSelectModal
           chain={validTokens[0].chain}

--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -173,12 +173,7 @@ export function RemoveLiquidityForm() {
             </Tooltip>
           </VStack>
         </Card>
-        <RemoveLiquidityModal
-          finalFocusRef={nextBtn}
-          isOpen={previewModalDisclosure.isOpen}
-          onOpen={previewModalDisclosure.onOpen}
-          onClose={onModalClose}
-        />
+        <RemoveLiquidityModal finalFocusRef={nextBtn} onClose={onModalClose} />
       </Box>
     </TokenBalancesProvider>
   )


### PR DESCRIPTION
Fixes animation jank in add/remove modals by setting modal min height when initially loaded. Success states are typically more condensed, so it reduces animation jank on the transition to the success state.