### PR TITLE
chore: ignore Library detector chrome extension error

### DIFF
--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -229,6 +229,12 @@ export function shouldIgnoreError(e: Error) {
 function shouldIgnore(e: Error): boolean {
   if (e.message.includes('.getAccounts is not a function')) return true
 
+  /*
+    Error thrown by Library detector chrome extension:
+    https://chromewebstore.google.com/detail/library-detector/cgaocdmhkmfnkdkbnckgmpopcbpaaejo?hl=en
+  */
+  if (e.message.includes(`Cannot set properties of null (setting 'content')`)) return true
+
   if (isUserRejectedError(e)) return true
 
   return false


### PR DESCRIPTION
Detecting and handling browser extension related errors is challenging but, at least, we can detect and ignore some of them like this one (we captured it in sentry 2 times).