### PR TITLE
fix: Reset path on swap success

### DIFF
--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -29,18 +29,16 @@ import { ChainSelect } from '../chains/ChainSelect'
 import { CheckCircle, Link, Repeat } from 'react-feather'
 import { SwapRate } from './SwapRate'
 import { SwapDetails } from './SwapDetails'
-import { capitalize, now } from 'lodash'
+import { capitalize } from 'lodash'
 import { motion, easeOut } from 'framer-motion'
 import FadeInOnView from '@/lib/shared/components/containers/FadeInOnView'
 import { ErrorAlert } from '@/lib/shared/components/errors/ErrorAlert'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
-import { useRouter } from 'next/navigation'
 import { parseSwapError } from './swap.helpers'
 import { useUserAccount } from '../web3/UserAccountProvider'
 import { ConnectWallet } from '../web3/ConnectWallet'
 
 export function SwapForm() {
-  const router = useRouter()
   const {
     tokenIn,
     tokenOut,
@@ -62,6 +60,7 @@ export function SwapForm() {
     switchTokens,
     setNeedsToAcceptHighPI,
     resetSwapAmounts,
+    replaceUrlPath,
   } = useSwap()
   const [copiedDeepLink, setCopiedDeepLink] = useState(false)
   const tokenSelectDisclosure = useDisclosure()
@@ -100,8 +99,7 @@ export function SwapForm() {
     previewModalDisclosure.onClose()
     if (swapTxHash) {
       resetSwapAmounts()
-      // Push an invalid dynamic route to force a re-render of the swap layout
-      router.push(`/swap/${now()}`)
+      replaceUrlPath()
     }
   }
 

--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -51,6 +51,7 @@ export function SwapForm() {
     simulationQuery,
     swapAction,
     swapTxHash,
+    transactionSteps,
     setSelectedChain,
     setTokenInAmount,
     setTokenOutAmount,
@@ -100,6 +101,7 @@ export function SwapForm() {
     if (swapTxHash) {
       resetSwapAmounts()
       replaceUrlPath()
+      transactionSteps.resetTransactionSteps()
     }
   }
 

--- a/lib/modules/swap/SwapProvider.tsx
+++ b/lib/modules/swap/SwapProvider.tsx
@@ -550,6 +550,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
     swapTxHash,
     hasQuoteContext,
     isWrap,
+    replaceUrlPath,
     resetSwapAmounts,
     setTokenSelectKey,
     setSelectedChain,

--- a/lib/modules/transactions/transaction-steps/TransactionStateProvider.tsx
+++ b/lib/modules/transactions/transaction-steps/TransactionStateProvider.tsx
@@ -26,9 +26,14 @@ export function _useTransactionState() {
     return transactionMap.get(id)
   }
 
+  function resetTransactionState() {
+    setTransactionMap(new Map())
+  }
+
   return {
     getTransaction,
     updateTransaction,
+    resetTransactionState,
   }
 }
 

--- a/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
+++ b/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
@@ -11,7 +11,7 @@ export type TransactionStepsResponse = ReturnType<typeof useTransactionSteps>
 export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = false) {
   const [currentStepIndex, setCurrentStepIndex] = useState<number>(0)
   const [onSuccessCalled, setOnSuccessCalled] = useState<boolean>(false)
-  const { getTransaction } = useTransactionState()
+  const { getTransaction, resetTransactionState } = useTransactionState()
   const [playGong] = useSound('/sounds/gong.mp3')
 
   const currentStep = steps?.[currentStepIndex]
@@ -28,6 +28,12 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
 
   function isLastStep(index: number) {
     return steps?.length ? index === lastStepIndex : false
+  }
+
+  function resetTransactionSteps() {
+    setCurrentStepIndex(0)
+    setOnSuccessCalled(false)
+    resetTransactionState()
   }
 
   // Trigger side effects on transaction completion. The step itself decides
@@ -83,5 +89,6 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
     lastTransactionConfirmingOrConfirmed,
     isLastStep,
     setCurrentStepIndex,
+    resetTransactionSteps,
   }
 }


### PR DESCRIPTION
After swap success, reset url path on modal close instead of pushing redirect.