### PR TITLE
fix: ignore ConnectorNotConnectedError

### DIFF
--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -227,7 +227,7 @@ export function shouldIgnoreError(e: Error) {
 }
 
 function shouldIgnore(e: Error): boolean {
-  if (!e.message) return false
+  if (!e?.message) return false
 
   if (e.message.includes('.getAccounts is not a function')) return true
 
@@ -236,6 +236,11 @@ function shouldIgnore(e: Error): boolean {
     https://chromewebstore.google.com/detail/library-detector/cgaocdmhkmfnkdkbnckgmpopcbpaaejo?hl=en
   */
   if (e.message.includes(`Cannot set properties of null (setting 'content')`)) return true
+
+  /*
+    Frequent error in rainbowkit + wagmi that does not mean a real crash
+  */
+  if (e.message.includes('ConnectorNotConnectedError: Connector not connected')) return true
 
   if (isUserRejectedError(e)) return true
 


### PR DESCRIPTION
Ignores ConnectorNotConnectedError error in Rainbowkit + Wagmi  that it is frequent but it does not mean a real crash.

https://balancer-labs.sentry.io/issues/5575379331/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0