### PR TITLE
fix: avoid undefined query data

### DIFF
--- a/lib/modules/pool/actions/claim/useClaimCallDataQuery.ts
+++ b/lib/modules/pool/actions/claim/useClaimCallDataQuery.ts
@@ -17,7 +17,10 @@ export function useClaimCallDataQuery(
   }
 
   const queryKey = ['claim', 'gauge', 'callData', inputData]
-  const queryFn = () => gaugeService && gaugeService.getGaugeClaimRewardsContractCallData(inputData)
+  const queryFn = (): `0x${string}`[] => {
+    if (!gaugeService) return []
+    return gaugeService.getGaugeClaimRewardsContractCallData(inputData)
+  }
 
   const query = useQuery({
     queryKey,


### PR DESCRIPTION
`queryFn` in react queries cannot return undefined but that was happening in `ve8020` pool  where `gaugeService` is undefined

So this fixes these errors: 
https://balancer-labs.sentry.io/issues/5576050491/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=7

