### PR TITLE
fix: relax 'Connector not connected' detection rule

### DIFF
--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -240,7 +240,7 @@ function shouldIgnore(e: Error): boolean {
   /*
     Frequent error in rainbowkit + wagmi that does not mean a real crash
   */
-  if (e.message.includes('ConnectorNotConnectedError: Connector not connected')) return true
+  if (e.message.includes('Connector not connected')) return true
 
   if (isUserRejectedError(e)) return true
 


### PR DESCRIPTION
The new string should also ignore errors like [this one](https://balancer-labs.sentry.io/issues/5576781302/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0) 