### PR TITLE
fix: improve error handling

### DIFF
--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -3,6 +3,7 @@
 import { AlertProps, Text } from '@chakra-ui/react'
 import { ErrorAlert } from './ErrorAlert'
 import { isUserRejectedError } from '../../utils/error-filters'
+import { ensureError } from '../../utils/errors'
 
 type ErrorWithOptionalShortMessage = Error & { shortMessage?: string }
 type Props = AlertProps & {
@@ -10,7 +11,8 @@ type Props = AlertProps & {
   customErrorName?: string
 }
 
-export function GenericError({ error, customErrorName, ...rest }: Props) {
+export function GenericError({ error: _error, customErrorName, ...rest }: Props) {
+  const error = ensureError(_error)
   if (isUserRejectedError(error)) return null
   const errorName = customErrorName ? `${customErrorName} (${error.name})` : error.name
   const errorMessage = error?.shortMessage || error.message

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -1,10 +1,3 @@
-import { ensureError } from './errors'
-
-export function shouldIgnoreExecutionError(error: Error): boolean {
-  const e = ensureError(error)
-  return isUserRejectedError(e)
-}
-
 export function isUserRejectedError(error: Error): boolean {
   return error.message.startsWith('User rejected the request.')
 }

--- a/lib/shared/utils/errors.ts
+++ b/lib/shared/utils/errors.ts
@@ -50,7 +50,7 @@ export class SentryError extends Error {
 }
 
 // Ensures returned value is an Error type.
-export function ensureError(value: unknown): Error {
+export function ensureError(value: unknown): Error & { shortMessage?: string } {
   if (value instanceof Error) return value
 
   let stringified = '[Unable to stringify thrown value]'
@@ -60,6 +60,22 @@ export function ensureError(value: unknown): Error {
     /* empty */
   }
 
-  const error = new Error(`This value was thrown as is, not through an Error: ${stringified}`)
+  const shortMessage = stringified
+  const error = new ErrorWithShortMessage(
+    `This value was thrown as is, not through an Error: ${stringified}`,
+    shortMessage
+  )
+
   return error
+}
+
+class ErrorWithShortMessage extends Error {
+  shortMessage: string
+
+  constructor(message: string, shortMessage: string) {
+    super(message)
+    this.shortMessage = shortMessage
+
+    Object.setPrototypeOf(this, ErrorWithShortMessage.prototype)
+  }
 }

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -1,7 +1,7 @@
 import { captureException } from '@sentry/nextjs'
 import { Extras, ScopeContext } from '@sentry/types'
 import { SentryError, ensureError } from './errors'
-import { isUserRejectedError, shouldIgnoreExecutionError } from './error-filters'
+import { isUserRejectedError } from './error-filters'
 import {
   AddLiquidityParams,
   stringifyHumanAmountsIn,
@@ -199,7 +199,7 @@ export function captureSentryError(
   { context, errorMessage, errorName }: SentryMetadata
 ) {
   const causeError = ensureError(e)
-  if (shouldIgnoreExecutionError(causeError)) return
+  if (isUserRejectedError(causeError)) return
 
   // Adding the root cause message to the top level message makes slack alerts more useful
   const errorMessageWithCause = errorMessage + `\n\nCause: \n` + causeError.message

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -229,6 +229,8 @@ export function shouldIgnoreError(e: Error) {
 function shouldIgnore(e: Error): boolean {
   if (!e?.message) return false
 
+  if (isUserRejectedError(e)) return true
+
   if (e.message.includes('.getAccounts is not a function')) return true
 
   /*


### PR DESCRIPTION
- Although `simulation.query.error` is typed as `Error`, we found a case where we were receiving a plain string. This fix calls `ensureError` to avoid fix related issues and adds shortMessage to improve the error display in the UI. 

- Remove duplicated `isUserRejectedError` function