### PR TITLE
fix: validate after loading token balances

### DIFF
--- a/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -203,6 +203,8 @@ export const TokenInput = forwardRef(
     }: InputProps & Props,
     ref
   ) => {
+    const { isBalancesLoading } = useTokenBalances()
+
     const [inputTitle, setInputTitle] = useState<string>('')
 
     const { colors } = useTheme()
@@ -224,9 +226,11 @@ export const TokenInput = forwardRef(
     const boxShadow = hasValidationError(token) ? `0 0 0 1px ${colors.red[500]}` : undefined
 
     useEffect(() => {
-      validateInput(value || '')
-      setInputTitle(value || '')
-    }, [value, token?.address])
+      if (!isBalancesLoading) {
+        validateInput(value || '')
+        setInputTitle(value || '')
+      }
+    }, [value, token?.address, isBalancesLoading])
 
     return (
       <Box


### PR DESCRIPTION
**Before** 
Reloading a swap route was validating before the user balances were loaded, that is, skipping input balance validation.

<img width="628" alt="before" src="https://github.com/user-attachments/assets/0c673c52-2d41-4699-a16d-5d69a43ef404">

**After**
We trigger validation once the token balances have been loaded:

<img width="605" alt="Screenshot 2024-07-19 at 16 48 28" src="https://github.com/user-attachments/assets/166c0df7-9aea-4a26-beff-a81cfbfbff0e">
