### PR TITLE
chore: improve simulation error in remove liquidity

### DIFF
--- a/lib/shared/components/errors/SimulationError.tsx
+++ b/lib/shared/components/errors/SimulationError.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@chakra-ui/react'
+import { GenericError } from './GenericError'
 
 type Props = {
   simulationQuery: {
@@ -9,9 +9,5 @@ type Props = {
 export function SimulationError({ simulationQuery }: Props) {
   if (!simulationQuery.isError) return
 
-  return (
-    <Alert rounded="md" status="error">
-      {simulationQuery.error?.shortMessage || 'Simulation error'}
-    </Alert>
-  )
+  return <GenericError error={simulationQuery.error}></GenericError>
 }


### PR DESCRIPTION
Uses `GenericError` component to display simulation error in remove liquidity flow:

**Before:** 

<img width="589" alt="before" src="https://github.com/user-attachments/assets/7e218eb8-b49c-4a67-aba6-170c44cc1fe3">

**After**

<img width="599" alt="after" src="https://github.com/user-attachments/assets/c3e41585-8b45-4f0b-8ae4-069fea28064d">
