### PR TITLE
Extend the pool query to revalidate once every 30 mins

### DIFF
--- a/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
+++ b/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
@@ -26,7 +26,7 @@ async function getPoolQuery(chain: ChainSlug, id: string) {
     variables,
     context: {
       fetchOptions: {
-        next: { revalidate: 30 },
+        next: { revalidate: 1800 },
       },
     },
   })


### PR DESCRIPTION
Extend the pool detail query revalidate time to 30 mins.

Vercel has changed its pricing model, making cache writes our biggest expense. We need to be a bit smarter about how often we re-cache. The pool query gets enriched with on-chain data immediately, so at worst we have stale data until the RPC query resolves.
