### PR TITLE
fix: use wagmi transports setup in viem client

### DIFF
--- a/lib/modules/web3/WagmiConfig.tsx
+++ b/lib/modules/web3/WagmiConfig.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { Chain, connectorsForWallets } from '@rainbow-me/rainbowkit'
+import { connectorsForWallets } from '@rainbow-me/rainbowkit'
 
-import { createConfig, fallback, http } from 'wagmi'
+import { createConfig } from 'wagmi'
 
-import { getGqlChain } from '@/lib/config/app.config'
-import { SupportedChainId } from '@/lib/config/config.types'
 import { getProjectConfig } from '@/lib/config/getProjectConfig'
 import {
   coinbaseWallet,
@@ -16,18 +14,8 @@ import {
   safeWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
-import { chains, rpcOverrides } from './ChainConfig'
-
-function getTransports(chain: Chain) {
-  const gqlChain = getGqlChain(chain.id as SupportedChainId)
-  const overrideRpcUrl = rpcOverrides[gqlChain]
-  const fallbackRpcUrl = rpcOverrides[gqlChain]
-  return fallback([http(overrideRpcUrl), http(), http(fallbackRpcUrl)])
-}
-
-const transports = Object.fromEntries(
-  chains.map(chain => [chain.id, getTransports(chain)])
-) as Record<number, ReturnType<typeof getTransports>>
+import { chains } from './ChainConfig'
+import { transports } from './transports'
 
 const appName = getProjectConfig().projectName
 const projectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_ID || ''

--- a/lib/modules/web3/transports.ts
+++ b/lib/modules/web3/transports.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { Chain } from '@rainbow-me/rainbowkit'
+
+import { fallback, http } from 'wagmi'
+
+import { getGqlChain } from '@/lib/config/app.config'
+import { SupportedChainId } from '@/lib/config/config.types'
+
+import { chains, rpcOverrides } from './ChainConfig'
+export function getTransports(chain: Chain) {
+  const gqlChain = getGqlChain(chain.id as SupportedChainId)
+  const overrideRpcUrl = rpcOverrides[gqlChain]
+  const fallbackRpcUrl = rpcOverrides[gqlChain]
+  return fallback([http(overrideRpcUrl), http(), http(fallbackRpcUrl)])
+}
+
+export const transports = Object.fromEntries(
+  chains.map(chain => [chain.id, getTransports(chain)])
+) as Record<number, ReturnType<typeof getTransports>>

--- a/lib/shared/services/viem/viem.client.ts
+++ b/lib/shared/services/viem/viem.client.ts
@@ -1,8 +1,9 @@
-import { createPublicClient, http } from 'viem'
+import { createPublicClient } from 'viem'
 import { GqlChain } from '../api/generated/graphql'
 import { getNetworkConfig } from '@/lib/config/app.config'
-import { chains } from '@/lib/modules/web3/ChainConfig'
+import { chains, chainsByKey } from '@/lib/modules/web3/ChainConfig'
 import { Chain } from 'viem'
+import { getTransports } from '@/lib/modules/web3/transports'
 
 function getViemChain(chainId: number): Chain {
   const chain = chains.find(chain => chain.id === chainId)
@@ -15,6 +16,6 @@ export function getViemClient(chain: GqlChain) {
 
   return createPublicClient({
     chain: getViemChain(chainId),
-    transport: http(),
+    transport: getTransports(chainsByKey[chainId]),
   })
 }


### PR DESCRIPTION
Using the default transports in `viem client` was causing 429 and other issues that are fixed if we use the same `transports` configuration that we use in `wagmi setup`.