### PR TITLE
Longer cache times on token queries, fix fetch policies

### DIFF
--- a/lib/modules/tokens/TokensProvider.tsx
+++ b/lib/modules/tokens/TokensProvider.tsx
@@ -40,8 +40,10 @@ export function _useTokens(
     GetTokenPricesDocument,
     {
       variables,
-      initialFetchPolicy: 'cache-only',
-      nextFetchPolicy: 'cache-first',
+      // The server provides us with an initial data set, but we immediately reload the potentially
+      // stale data to ensure the prices we show are up to date. Every 3 mins, we requery token prices
+      initialFetchPolicy: 'no-cache',
+      nextFetchPolicy: 'cache-and-network',
       pollInterval: mins(3).toMs(),
       notifyOnNetworkStatusChange: true,
     }

--- a/lib/shared/services/api/apollo-global-data.provider.tsx
+++ b/lib/shared/services/api/apollo-global-data.provider.tsx
@@ -33,7 +33,7 @@ export async function ApolloGlobalDataProvider({ children }: React.PropsWithChil
     variables: tokensQueryVariables,
     context: {
       fetchOptions: {
-        next: { revalidate: 600 }, // 10 minutes, but this could potentially be longer
+        next: { revalidate: 1200 }, // 20 minutes
       },
     },
   })
@@ -45,7 +45,7 @@ export async function ApolloGlobalDataProvider({ children }: React.PropsWithChil
     },
     context: {
       fetchOptions: {
-        next: { revalidate: 60 },
+        next: { revalidate: 600 }, // 10 minutes
       },
     },
   })

--- a/lib/shared/services/api/apollo-global-data.provider.tsx
+++ b/lib/shared/services/api/apollo-global-data.provider.tsx
@@ -18,6 +18,7 @@ import { FiatFxRatesProvider } from '../../hooks/FxRatesProvider'
 import { getFxRates } from '../../utils/currencies'
 import { getPoolCategories } from '@/lib/modules/pool/categories/getPoolCategories'
 import { PoolCategoriesProvider } from '@/lib/modules/pool/categories/PoolCategoriesProvider'
+import { mins } from '../../utils/time'
 
 export const revalidate = 60
 
@@ -33,7 +34,7 @@ export async function ApolloGlobalDataProvider({ children }: React.PropsWithChil
     variables: tokensQueryVariables,
     context: {
       fetchOptions: {
-        next: { revalidate: 1200 }, // 20 minutes
+        next: { revalidate: mins(20).toSecs() },
       },
     },
   })
@@ -45,7 +46,7 @@ export async function ApolloGlobalDataProvider({ children }: React.PropsWithChil
     },
     context: {
       fetchOptions: {
-        next: { revalidate: 600 }, // 10 minutes
+        next: { revalidate: mins(10).toSecs() },
       },
     },
   })


### PR DESCRIPTION
- Extend the revalidate time on the tokens query to 20 minutes. New tokens are only rarely, so 20 minutes should plenty of a refresh interval
- Extend the revalidate time on the token prices query to 10 minutes.
  - We now load token prices immediately on page load so the server prices are just placeholder
- Fix the fetch policies on the token price query. We had a poll interval, but the `cache-first` policy meant that it would never query the network.