### PR TITLE
fix: show alert when the pool requires proportional adds but has no liquidity

### DIFF
--- a/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -4,7 +4,7 @@ import { nullAddress } from '@/lib/modules/web3/contracts/wagmi-helpers'
 import { GqlChain, GqlPoolType, GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { isSameAddress } from '@/lib/shared/utils/addresses'
 import { SentryError } from '@/lib/shared/utils/errors'
-import { bn } from '@/lib/shared/utils/numbers'
+import { bn, isZero } from '@/lib/shared/utils/numbers'
 import {
   HumanAmount,
   InputAmount,
@@ -312,4 +312,8 @@ export function injectNativeAsset(
     return [nativeAsset, ...validTokens]
   }
   return validTokens
+}
+
+export function hasNoLiquidity(pool: Pool): boolean {
+  return isZero(pool.dynamicData.totalShares)
 }

--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -142,9 +142,6 @@ function AddLiquidityMainForm() {
     }
   }, [addLiquidityTxHash])
 
-  const requiresProportionalInputAndHasNoLiquidity =
-    requiresProportionalInput(pool.type) && hasNoLiquidity(pool)
-
   return (
     <Box w="full" maxW="lg" mx="auto">
       <Card>
@@ -154,97 +151,93 @@ function AddLiquidityMainForm() {
             <TransactionSettings size="sm" />
           </HStack>
         </CardHeader>
-
-        {requiresProportionalInputAndHasNoLiquidity ? (
-          <VStack spacing="md" w="full">
+        <VStack spacing="md" align="start" w="full">
+          {hasNoLiquidity(pool) && (
             <BalAlert status="warning" content="You cannot add because the pool has no liquidity" />
-          </VStack>
-        ) : (
-          <VStack spacing="md" align="start" w="full">
-            {supportsProportionalAdds(pool) ? (
-              <TokenInputsWithAddable
-                tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()}
-                requiresProportionalInput={requiresProportionalInput(pool.type)}
-                totalUSDValue={totalUSDValue}
-              />
-            ) : (
-              <TokenInputs tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()} />
-            )}
-            <VStack spacing="sm" align="start" w="full">
-              <PriceImpactAccordion
-                isDisabled={!priceImpactQuery.data}
-                cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
-                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
-                accordionButtonComponent={
-                  <HStack>
-                    <Text variant="secondary" fontSize="sm" color="gray.400">
-                      Price impact:{' '}
-                    </Text>
-                    <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
-                      {priceImpactLabel}
-                    </Text>
-                  </HStack>
-                }
-                accordionPanelComponent={
-                  <PoolActionsPriceImpactDetails
-                    totalUSDValue={totalUSDValue}
-                    bptAmount={simulationQuery.data?.bptOut.amount}
-                    isAddLiquidity
-                  />
-                }
-              />
-            </VStack>
-            <Grid w="full" templateColumns="1fr 1fr" gap="sm">
-              <GridItem>
-                <Card minHeight="full" variant="subSection" w="full" p={['sm', 'ms']}>
-                  <VStack align="start" gap="sm">
-                    <Text fontSize="sm" lineHeight="16px" fontWeight="500">
-                      Total
-                    </Text>
-                    <Text fontSize="md" lineHeight="16px" fontWeight="700">
-                      {totalUSDValue !== '0'
-                        ? toCurrency(totalUSDValue, { abbreviated: false })
-                        : '-'}
-                    </Text>
-                  </VStack>
-                </Card>
-              </GridItem>
-              <GridItem>
-                <AddLiquidityAprTooltip
-                  aprItems={pool.dynamicData.aprItems}
-                  totalUsdValue={totalUSDValue}
-                  weeklyYield={weeklyYield}
-                  pool={pool}
+          )}
+          {supportsProportionalAdds(pool) ? (
+            <TokenInputsWithAddable
+              tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()}
+              requiresProportionalInput={requiresProportionalInput(pool.type)}
+              totalUSDValue={totalUSDValue}
+            />
+          ) : (
+            <TokenInputs tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()} />
+          )}
+          <VStack spacing="sm" align="start" w="full">
+            <PriceImpactAccordion
+              isDisabled={!priceImpactQuery.data}
+              cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
+              setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
+              accordionButtonComponent={
+                <HStack>
+                  <Text variant="secondary" fontSize="sm" color="gray.400">
+                    Price impact:{' '}
+                  </Text>
+                  <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
+                    {priceImpactLabel}
+                  </Text>
+                </HStack>
+              }
+              accordionPanelComponent={
+                <PoolActionsPriceImpactDetails
+                  totalUSDValue={totalUSDValue}
+                  bptAmount={simulationQuery.data?.bptOut.amount}
+                  isAddLiquidity
                 />
-              </GridItem>
-            </Grid>
-            {showAcceptPoolRisks && <AddLiquidityFormCheckbox />}
-            {priceImpactQuery.isError && <PriceImpactError priceImpactQuery={priceImpactQuery} />}
-            {simulationQuery.isError && (
-              <GenericError
-                customErrorName={'Error in query simulation'}
-                error={simulationQuery.error}
-              ></GenericError>
-            )}
-            {isConnected ? (
-              <Tooltip label={isDisabled ? disabledReason : ''}>
-                <Button
-                  ref={nextBtn}
-                  variant="secondary"
-                  w="full"
-                  size="lg"
-                  isDisabled={isDisabled}
-                  isLoading={simulationQuery.isLoading || priceImpactQuery.isLoading}
-                  onClick={() => !isDisabled && onModalOpen()}
-                >
-                  Next
-                </Button>
-              </Tooltip>
-            ) : (
-              <ConnectWallet variant="primary" w="full" size="lg" />
-            )}
+              }
+            />
           </VStack>
-        )}
+          <Grid w="full" templateColumns="1fr 1fr" gap="sm">
+            <GridItem>
+              <Card minHeight="full" variant="subSection" w="full" p={['sm', 'ms']}>
+                <VStack align="start" gap="sm">
+                  <Text fontSize="sm" lineHeight="16px" fontWeight="500">
+                    Total
+                  </Text>
+                  <Text fontSize="md" lineHeight="16px" fontWeight="700">
+                    {totalUSDValue !== '0'
+                      ? toCurrency(totalUSDValue, { abbreviated: false })
+                      : '-'}
+                  </Text>
+                </VStack>
+              </Card>
+            </GridItem>
+            <GridItem>
+              <AddLiquidityAprTooltip
+                aprItems={pool.dynamicData.aprItems}
+                totalUsdValue={totalUSDValue}
+                weeklyYield={weeklyYield}
+                pool={pool}
+              />
+            </GridItem>
+          </Grid>
+          {showAcceptPoolRisks && <AddLiquidityFormCheckbox />}
+          {priceImpactQuery.isError && <PriceImpactError priceImpactQuery={priceImpactQuery} />}
+          {simulationQuery.isError && (
+            <GenericError
+              customErrorName={'Error in query simulation'}
+              error={simulationQuery.error}
+            ></GenericError>
+          )}
+          {isConnected ? (
+            <Tooltip label={isDisabled ? disabledReason : ''}>
+              <Button
+                ref={nextBtn}
+                variant="secondary"
+                w="full"
+                size="lg"
+                isDisabled={isDisabled}
+                isLoading={simulationQuery.isLoading || priceImpactQuery.isLoading}
+                onClick={() => !isDisabled && onModalOpen()}
+              >
+                Next
+              </Button>
+            </Tooltip>
+          ) : (
+            <ConnectWallet variant="primary" w="full" size="lg" />
+          )}
+        </VStack>
       </Card>
       <AddLiquidityModal
         finalFocusRef={nextBtn}

--- a/lib/modules/pool/actions/add-liquidity/form/TokenInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/TokenInputs.tsx
@@ -4,7 +4,7 @@ import { Address } from 'viem'
 import { useAddLiquidity } from '../AddLiquidityProvider'
 import { VStack } from '@chakra-ui/react'
 import { usePool } from '../../../PoolProvider'
-import { shouldShowNativeWrappedSelector } from '../../LiquidityActionHelpers'
+import { hasNoLiquidity, shouldShowNativeWrappedSelector } from '../../LiquidityActionHelpers'
 
 type Props = {
   tokenSelectDisclosureOpen: () => void
@@ -56,6 +56,7 @@ export function TokenInputs({ tokenSelectDisclosureOpen, customSetAmountIn }: Pr
                 ? tokenSelectDisclosureOpen
                 : undefined
             }
+            isDisabled={hasNoLiquidity(pool)}
           />
         )
       })}

--- a/lib/modules/pool/actions/add-liquidity/form/TokenInputsWithAddable.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/TokenInputsWithAddable.tsx
@@ -10,6 +10,8 @@ import { TokenInputs } from './TokenInputs'
 import { useProportionalInputs } from './useProportionalInputs'
 import { useMaximumInputs } from './useMaximumInputs'
 import { BalAlert } from '@/lib/shared/components/alerts/BalAlert'
+import { hasNoLiquidity } from '../../LiquidityActionHelpers'
+import { usePool } from '../../../PoolProvider'
 
 type Props = {
   tokenSelectDisclosureOpen: () => void
@@ -36,6 +38,7 @@ export function TokenInputsWithAddable({
     setIsMaximized: setIsMaximizedForProportionalInput,
     clearAmountsIn,
   } = useProportionalInputs()
+  const { pool } = usePool()
 
   const {
     canMaximize: canMaximizeForMaximumInput,
@@ -81,7 +84,7 @@ export function TokenInputsWithAddable({
 
   return (
     <VStack spacing="md" w="full">
-      {requiresProportionalInput && (
+      {requiresProportionalInput && !hasNoLiquidity(pool) && (
         <BalAlert status="info" content="This pool requires liquidity to be added proportionally" />
       )}
       {isConnected && (

--- a/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
@@ -10,7 +10,11 @@ import { Address, HumanAmount, InputAmount, calculateProportionalAmounts } from 
 import { useMemo, useState } from 'react'
 import { formatUnits } from 'viem'
 import { usePool } from '../../../PoolProvider'
-import { LiquidityActionHelpers, isEmptyHumanAmount } from '../../LiquidityActionHelpers'
+import {
+  LiquidityActionHelpers,
+  hasNoLiquidity,
+  isEmptyHumanAmount,
+} from '../../LiquidityActionHelpers'
 import { useAddLiquidity } from '../AddLiquidityProvider'
 import { useTotalUsdValue } from '@/lib/modules/tokens/useTotalUsdValue'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
@@ -34,7 +38,7 @@ export function useProportionalInputs() {
   } = useAddLiquidity()
   const { usdValueFor } = useTotalUsdValue(validTokens)
   const { balanceFor, balances, isBalancesLoading } = useTokenBalances()
-  const { isLoading: isPoolLoading } = usePool()
+  const { isLoading: isPoolLoading, pool } = usePool()
   const [isMaximized, setIsMaximized] = useState(false)
   const { isLoadingTokenPrices } = useTokens()
 
@@ -94,7 +98,7 @@ export function useProportionalInputs() {
     (where the rest of the tokens have enough user balance for that proportional result).
   */
   const optimalToken = useMemo((): OptimalToken | undefined => {
-    if (isLoadingTokenPrices || !shouldCalculateMaximizeAmounts) return
+    if (isLoadingTokenPrices || !shouldCalculateMaximizeAmounts || hasNoLiquidity(pool)) return
 
     const humanBalanceFor = (tokenAddress: string): HumanAmount => {
       return (balanceFor(tokenAddress)?.formatted || '0') as HumanAmount


### PR DESCRIPTION
Example pool to test: 
`pools/ethereum/cow/0x232a18645c4e33dd64e6925e03da0f0dd77ad003/add-liquidity`

**Before**: 
Opening the addLiquidity url of a pool that requires proportional (gyro or CoW) but does no have liquidity (`totalShares===0`) leads to different errors. 

**After:** 
We show an alert and disable inputs:

![Screenshot 2024-07-26 at 09 20 32](https://github.com/user-attachments/assets/642b080e-ad1a-4919-8e8a-70e4ee6aeaf5)


