### PR TITLE
fix: show error message if sent tokens are empty

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityReceipt.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityReceipt.tsx
@@ -24,6 +24,11 @@ export function AddLiquidityReceipt({ txHash }: { txHash: Hash }) {
 
   if (!isUserAddressLoading && !userAddress) return <Text>User is not connected</Text>
   if (error) return <Text>We were unable to find this transaction hash</Text>
+  if (!isLoading && !sentTokens.length) {
+    return (
+      <Text>We were unable to find logs for this transaction hash and the connected account</Text>
+    )
+  }
 
   return (
     <VStack spacing="sm" align="start">


### PR DESCRIPTION
Fixes error: 
![352546425-ef1bc0af-c15d-4f4f-89a0-c2dc59d30812](https://github.com/user-attachments/assets/a4eef30c-48b1-4ccb-96dc-9513b64d43d1)

**Hypothesis**:
When a transaction is executed, it may take some time before it is written to the logs. It is usually immediate, but in this case, there might have been a delay. 

**Solution**:
Showing `isLoading` while `blockHash` is undefined, prevents from showing empty receipt data while the logs are being written.

If `blockHash` is defined but `sentTokens` are empty we show an error (this should only happen if the connected `userAddress` is different from the `userAddress` that sent the transaction).

