### PR TITLE
fix: avoid redirection when openning receipt page from url

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
@@ -16,9 +16,8 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { SuccessOverlay } from '@/lib/shared/components/modals/SuccessOverlay'
 import { usePoolRedirect } from '../../../pool.hooks'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
-import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
-import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
 import { useResetStepIndexOnOpen } from '../../useResetStepIndexOnOpen'
+import { useOnUserAccountChanged } from '@/lib/modules/web3/useOnUserAccountChanged'
 
 type Props = {
   isOpen: boolean
@@ -39,8 +38,6 @@ export function AddLiquidityModal({
     useAddLiquidity()
   const { pool } = usePool()
   const { redirectToPoolPage } = usePoolRedirect(pool)
-  const isMounted = useIsMounted()
-  const { userAddress } = useUserAccount()
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
@@ -50,13 +47,10 @@ export function AddLiquidityModal({
     }
   }, [addLiquidityTxHash])
 
-  useEffect(() => {
-    if (isMounted) {
-      setInitialHumanAmountsIn()
-      onClose()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userAddress])
+  useOnUserAccountChanged(() => {
+    setInitialHumanAmountsIn()
+    onClose()
+  })
 
   return (
     <Modal

--- a/lib/modules/web3/useOnUserAccountChanged.tsx
+++ b/lib/modules/web3/useOnUserAccountChanged.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+import { useUserAccount } from './UserAccountProvider'
+import { Address } from 'viem'
+import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
+import { emptyAddress } from './contracts/wagmi-helpers'
+
+export function useOnUserAccountChanged(callback: () => void) {
+  const [prevUserAddress, setPrevUserAddress] = useState<Address>()
+  const { userAddress } = useUserAccount()
+  const isMounted = useIsMounted()
+
+  useEffect(() => {
+    if (isMounted && prevUserAddress !== emptyAddress) {
+      callback()
+    }
+    setPrevUserAddress(userAddress)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userAddress])
+}


### PR DESCRIPTION
The old code was preventing users from loading a receipt page from its url as the `userAddress` was always changing after `isMounted`. 

The new `useOnUserAccountChanged` hook encapsulates the logic and makes sure that a real user account change has happened. 

TODO: 
We should apply the same fix to other flows.