### PR TITLE
fix: redirection when loading receipt page (for swaps and removes)

### DIFF
--- a/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
@@ -16,9 +16,8 @@ import { ActionModalFooter } from '../../../../../shared/components/modals/Actio
 import { RemoveLiquidityReceipt } from './RemoveLiquidityReceipt'
 import { usePoolRedirect } from '../../../pool.hooks'
 import { TransactionModalHeader } from '@/lib/shared/components/modals/TransactionModalHeader'
-import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
-import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
 import { useResetStepIndexOnOpen } from '../../useResetStepIndexOnOpen'
+import { useOnUserAccountChanged } from '@/lib/modules/web3/useOnUserAccountChanged'
 
 type Props = {
   isOpen: boolean
@@ -38,8 +37,6 @@ export function RemoveLiquidityModal({
   const { transactionSteps, removeLiquidityTxHash, hasQuoteContext } = useRemoveLiquidity()
   const { pool } = usePool()
   const { redirectToPoolPage } = usePoolRedirect(pool)
-  const { userAddress } = useUserAccount()
-  const isMounted = useIsMounted()
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
@@ -49,10 +46,7 @@ export function RemoveLiquidityModal({
     }
   }, [removeLiquidityTxHash])
 
-  useEffect(() => {
-    if (isMounted) redirectToPoolPage()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userAddress])
+  useOnUserAccountChanged(redirectToPoolPage)
 
   return (
     <Modal

--- a/lib/modules/swap/modal/SwapModal.tsx
+++ b/lib/modules/swap/modal/SwapModal.tsx
@@ -15,9 +15,8 @@ import { chainToSlugMap } from '../../pool/pool.utils'
 import { getStylesForModalContentWithStepTracker } from '../../transactions/transaction-steps/step-tracker/step-tracker.utils'
 import { SwapModalBody } from './SwapModalBody'
 import { SuccessOverlay } from '@/lib/shared/components/modals/SuccessOverlay'
-import { useUserAccount } from '../../web3/UserAccountProvider'
-import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
 import { useResetStepIndexOnOpen } from '../../pool/actions/useResetStepIndexOnOpen'
+import { useOnUserAccountChanged } from '../../web3/useOnUserAccountChanged'
 
 type Props = {
   isOpen: boolean
@@ -33,8 +32,6 @@ export function SwapPreviewModal({
   ...rest
 }: Props & Omit<ModalProps, 'children'>) {
   const { isDesktop } = useBreakpoints()
-  const { userAddress } = useUserAccount()
-  const isMounted = useIsMounted()
   const initialFocusRef = useRef(null)
 
   const { transactionSteps, swapAction, isWrap, selectedChain, swapTxHash, hasQuoteContext } =
@@ -49,13 +46,7 @@ export function SwapPreviewModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [swapTxHash])
 
-  useEffect(() => {
-    if (isMounted) {
-      onClose()
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userAddress])
+  useOnUserAccountChanged(onClose)
 
   return (
     <Modal


### PR DESCRIPTION
We applied this fix for Add flow [here](https://github.com/balancer/frontend-v3/pull/887)

Now we fix the same issues for removes and swaps.