### PR TITLE
fix: ignore undefined token in handleTokenSelect

### DIFF
--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -82,6 +82,7 @@ export function SwapForm() {
   }
 
   function handleTokenSelect(token: GqlToken) {
+    if (!token) return
     if (tokenSelectKey === 'tokenIn') {
       setTokenIn(token.address as Address)
     } else if (tokenSelectKey === 'tokenOut') {


### PR DESCRIPTION
I couldn't reproduce it but we have several sentry errors where token is `undefined`:
https://balancer-labs.sentry.io/issues/5621464688/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+Cannot+read+properties+of+undefined+%28reading+%27address%27%29&referrer=issue-stream&statsPeriod=7d&stream_index=4

I don't think it is a real bug so I believe it is better to ignore it. If someone reproduces it, then we can try to fix the root cause. 