### PR TITLE
fix: usePathName instead of window to detect CoW urls

### DIFF
--- a/lib/modules/transactions/transaction-steps/useTxSound.ts
+++ b/lib/modules/transactions/transaction-steps/useTxSound.ts
@@ -1,8 +1,11 @@
 import useSound from 'use-sound'
 import { StepType } from './lib'
+import { usePathname } from 'next/navigation'
 
 export function useTxSound() {
-  const isCowTransaction = window.location.pathname.includes('cow')
+  const pathname = usePathname()
+
+  const isCowTransaction = pathname.includes('/cow/')
   const successSoundSrc = isCowTransaction ? '/sounds/successMoo.mp3' : '/sounds/gong.mp3'
   const [playSuccessSound] = useSound(successSoundSrc)
 

--- a/test/vitest/setup-vitest.tsx
+++ b/test/vitest/setup-vitest.tsx
@@ -27,6 +27,9 @@ vi.mock('next/navigation', async importOriginal => {
     useParams: () => {
       return { variant: 'v2' }
     },
+    usePathname: () => {
+      return 'testPathName'
+    },
   }
 })
 


### PR DESCRIPTION
Fixes this scenario: 

You are in a CoW AMM pool and navigate to swaps. 
`window.location.pathname` is not properly updated but `usePathname` is.