### PR TITLE
chore: Subtract 10 wei from bptAmount out

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
@@ -43,6 +43,8 @@ export class ProportionalAddLiquidityHandler implements AddLiquidityHandler {
       humanAmountIn
     )
 
+    bptAmount.rawAmount = bptAmount.rawAmount - 10n // Subtract 10 wei to ensure query doesn't fail when user maxes out balance.
+
     const addLiquidity = new AddLiquidity()
 
     const addLiquidityInput = this.constructSdkInput(humanAmountsIn, bptAmount)


### PR DESCRIPTION
In the proportional add liquidity handler we want to subtract 10 wei from the bptAmount out that is calculated with the SDK helper. This bpt amount is then fed into the stimulation query and ensures that it always works if the user has maxed out one of their token balances. It's possible even with subtracting 10 wei that this could fail. If we see evidence that this is happening often we can increase this buffer up to 100 wei.