### PR TITLE
fix: Disable useTransaction query when txHash is undefined

### DIFF
--- a/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
+++ b/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
@@ -163,7 +163,7 @@ export function useTransactionLogsQuery({
   const chainId = getChainId(chain)
   const networkConfig = getNetworkConfig(chain)
   const viemClient = getViemClient(chain)
-  const receipt = useTransaction({ hash: txHash, chainId })
+  const receipt = useTransaction({ hash: txHash, chainId, query: { enabled: !!txHash } })
 
   const blockHash = receipt.data?.blockHash
 

--- a/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
+++ b/lib/modules/transactions/transaction-steps/useTransactionLogsQuery.ts
@@ -163,7 +163,11 @@ export function useTransactionLogsQuery({
   const chainId = getChainId(chain)
   const networkConfig = getNetworkConfig(chain)
   const viemClient = getViemClient(chain)
-  const receipt = useTransaction({ hash: txHash, chainId, query: { enabled: !!txHash } })
+  const receipt = useTransaction({
+    hash: txHash,
+    chainId,
+    query: { enabled: !!txHash && !!chainId },
+  })
 
   const blockHash = receipt.data?.blockHash
 


### PR DESCRIPTION
Wagmi does not automatically handle disable `useTransaction` when passing an empty transaction `hash`. It thows an error instead: 
https://github.com/wevm/wagmi/blob/fd0e4cac2bdb57cbcdeb62d33560a79d3bd8bb67/packages/core/src/query/getTransaction.ts#L29

This will fix this[kind of sentry issue](https://balancer-labs.sentry.io/issues/5668551307/events/af9797d0950a487da4056eafbfd31ad7/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=previous-event&statsPeriod=30d&stream_index=4) that we introduced in a recent refactor.

