### PR TITLE
Remove jank from filter button interactions

### DIFF
--- a/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -8,6 +8,7 @@ import {
   ButtonProps,
   Center,
   Checkbox,
+  Flex,
   forwardRef,
   Heading,
   HStack,
@@ -26,6 +27,7 @@ import {
   TagCloseButton,
   TagLabel,
   Text,
+  VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
 import { PoolListSearch } from './PoolListSearch'
@@ -51,6 +53,19 @@ import { usePoolList } from './PoolListProvider'
 
 const SLIDER_MAX_VALUE = 10000000
 const SLIDER_STEP_SIZE = 100000
+
+export function useFilterTagsVisible() {
+  const { networks, poolTypes, minTvl, poolCategories } = usePoolListQueryState()
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    setIsVisible(
+      networks.length > 0 || poolTypes.length > 0 || minTvl > 0 || poolCategories.length > 0
+    )
+  }, [networks, poolTypes, minTvl, poolCategories])
+
+  return isVisible
+}
 
 function UserPoolFilter() {
   const { userAddress, toggleUserAddress } = usePoolListQueryState()
@@ -230,39 +245,99 @@ export function FilterTags() {
   }
 
   return (
-    <HStack spacing="sm" wrap="wrap" mt="2">
-      {poolTypes.map(poolType => (
-        <Tag key={poolType} size="lg">
-          <TagLabel>{poolTypeLabel(poolType)}</TagLabel>
-          <TagCloseButton onClick={() => togglePoolType(false, poolType)} />
-        </Tag>
-      ))}
-      {networks.map(network => (
-        <Tag key={network} size="lg">
-          <TagLabel>
-            <Text fontWeight="bold" textTransform="capitalize">
-              {network.toLowerCase()}
-            </Text>
-          </TagLabel>
-          <TagCloseButton onClick={() => toggleNetwork(false, network)} />
-        </Tag>
-      ))}
+    <HStack spacing="sm" wrap="wrap">
+      <AnimatePresence>
+        {poolTypes.map(poolType => (
+          <motion.div
+            key={poolType}
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 40 }}
+            exit={{ opacity: 0, y: 0 }}
+            transition={{
+              enter: { ease: 'easeOut', duration: 0.15, delay: 0.05 },
+              exit: { ease: 'easeIn', duration: 0.05, delay: 0 },
+            }}
+          >
+            <Tag size="lg">
+              <TagLabel>
+                <Text fontSize="sm" fontWeight="bold" textTransform="capitalize">
+                  {poolTypeLabel(poolType)}
+                </Text>
+              </TagLabel>
+              <TagCloseButton onClick={() => togglePoolType(false, poolType)} />
+            </Tag>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+      <AnimatePresence>
+        {networks.map(network => (
+          <motion.div
+            key={network}
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 40 }}
+            exit={{ opacity: 0, y: 0 }}
+            transition={{
+              enter: { ease: 'easeOut', duration: 0.15, delay: 0.05 },
+              exit: { ease: 'easeIn', duration: 0.05, delay: 0 },
+            }}
+          >
+            <Tag size="lg">
+              <TagLabel>
+                <Text fontSize="sm" fontWeight="bold" textTransform="capitalize">
+                  {network.toLowerCase()}
+                </Text>
+              </TagLabel>
+              <TagCloseButton onClick={() => toggleNetwork(false, network)} />
+            </Tag>
+          </motion.div>
+        ))}
+      </AnimatePresence>
       {minTvl > 0 && (
-        <Tag key="minTvl" size="lg">
-          <TagLabel>
-            <Text fontWeight="bold" textTransform="capitalize">
-              {`TVL > ${toCurrency(minTvl)}`}
-            </Text>
-          </TagLabel>
-          <TagCloseButton onClick={() => setMinTvl(0)} />
-        </Tag>
+        <AnimatePresence>
+          <motion.div
+            key="minTvl"
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 40 }}
+            exit={{ opacity: 0, y: 0 }}
+            transition={{
+              enter: { ease: 'easeOut', duration: 0.15, delay: 0.05 },
+              exit: { ease: 'easeIn', duration: 0.05, delay: 0 },
+            }}
+          >
+            <Tag size="lg">
+              <TagLabel>
+                <Text fontSize="sm" fontWeight="bold" textTransform="capitalize">
+                  {`TVL > ${toCurrency(minTvl)}`}
+                </Text>
+              </TagLabel>
+              <TagCloseButton onClick={() => setMinTvl(0)} />
+            </Tag>
+          </motion.div>
+        </AnimatePresence>
       )}
-      {poolCategories.map(poolCategory => (
-        <Tag key={poolCategory} size="lg">
-          <TagLabel>{poolCategoryLabel(poolCategory)}</TagLabel>
-          <TagCloseButton onClick={() => togglePoolCategory(false, poolCategory)} />
-        </Tag>
-      ))}
+      <AnimatePresence>
+        {poolCategories.map(poolCategory => (
+          <motion.div
+            key={poolCategory}
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 40 }}
+            exit={{ opacity: 0, y: 0 }}
+            transition={{
+              enter: { ease: 'easeOut', duration: 0.15, delay: 0.05 },
+              exit: { ease: 'easeIn', duration: 0.05, delay: 0 },
+            }}
+          >
+            <Tag size="lg">
+              <TagLabel>
+                <Text fontSize="sm" fontWeight="bold" textTransform="capitalize">
+                  {poolCategoryLabel(poolCategory)}
+                </Text>
+              </TagLabel>
+              <TagCloseButton onClick={() => togglePoolCategory(false, poolCategory)} />
+            </Tag>
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </HStack>
   )
 }
@@ -294,7 +369,7 @@ export function PoolListFilters() {
 
   return (
     <VStack w="full">
-      <HStack w="full" spacing="none" justify="end">
+      <HStack w="full" spacing="none" justify="end" gap="xs">
         <PoolListSearch />
         <Popover
           isOpen={isPopoverOpen}
@@ -320,30 +395,28 @@ export function PoolListFilters() {
                       exit="exit"
                       variants={staggeredFadeInUp}
                     >
-                      <Box
-                        lineHeight="0"
-                        p="0"
-                        mb="sm"
-                        as={motion.div}
-                        variants={staggeredFadeInUp}
-                      >
-                        <Text
-                          variant="eyebrow"
-                          background="font.special"
-                          backgroundClip="text"
-                          fontSize="xs"
-                          display="inline"
-                          lineHeight="1"
-                        >
-                          Filters
-                        </Text>
-                      </Box>
+                      <Box lineHeight="0" p="0" as={motion.div} variants={staggeredFadeInUp}>
+                        <Flex gap="ms" alignItems="center" w="full" justifyContent="space-between">
+                          <Text
+                            variant="eyebrow"
+                            background="font.special"
+                            backgroundClip="text"
+                            fontSize="xs"
+                            display="inline"
+                            lineHeight="1"
+                          >
+                            Filters
+                          </Text>
 
-                      {totalFilterCount > 0 && (
-                        <Button size="xs" w="full" onClick={resetFilters}>
-                          Reset filters
-                        </Button>
-                      )}
+                          <Button size="xs" variant="link" onClick={resetFilters}>
+                            {totalFilterCount === 0 ? (
+                              <VisuallyHidden>Reset all</VisuallyHidden>
+                            ) : (
+                              'Reset all'
+                            )}
+                          </Button>
+                        </Flex>
+                      </Box>
 
                       {isConnected && (
                         <Box as={motion.div} variants={staggeredFadeInUp}>

--- a/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -27,6 +27,7 @@ import {
   TagCloseButton,
   TagLabel,
   Text,
+  useColorModeValue,
   VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
@@ -345,13 +346,23 @@ export function FilterTags() {
 const FilterButton = forwardRef<ButtonProps, 'button'>((props, ref) => {
   const { totalFilterCount } = usePoolListQueryState()
   const { isMobile } = useBreakpoints()
+  const textColor = useColorModeValue('#fff', 'font.dark')
 
   return (
     <Button ref={ref} {...props} display="flex" gap="2" variant="tertiary">
       <Icon as={Filter} boxSize={4} />
       {!isMobile && 'Filters'}
       {totalFilterCount > 0 && (
-        <Badge colorScheme="green" borderRadius="full" p="0">
+        <Badge
+          bg="font.highlight"
+          color={textColor}
+          borderRadius="full"
+          p="0"
+          position="absolute"
+          right="-9px"
+          top="-9px"
+          shadow="lg"
+        >
           <Center h="5" w="5">
             {totalFilterCount}
           </Center>
@@ -369,7 +380,7 @@ export function PoolListFilters() {
 
   return (
     <VStack w="full">
-      <HStack w="full" spacing="none" justify="end" gap="xs">
+      <HStack w="full" spacing="none" justify="end" gap="0">
         <PoolListSearch />
         <Popover
           isOpen={isPopoverOpen}
@@ -377,7 +388,7 @@ export function PoolListFilters() {
           onClose={() => setIsPopoverOpen(false)}
         >
           <PopoverTrigger>
-            <FilterButton ml="sm" />
+            <FilterButton ml="ms" />
           </PopoverTrigger>
           <Box zIndex="popover" shadow="2xl">
             <PopoverContent>

--- a/lib/modules/pool/PoolList/PoolListLayout.tsx
+++ b/lib/modules/pool/PoolList/PoolListLayout.tsx
@@ -1,13 +1,25 @@
 'use client'
 
-import { Heading, Stack, HStack, VStack } from '@chakra-ui/react'
-import { FilterTags, PoolListFilters } from './PoolListFilters'
+import { Box, Heading, Stack, HStack, VStack, useBreakpointValue } from '@chakra-ui/react'
+import { motion } from 'framer-motion'
+import { FilterTags, PoolListFilters, useFilterTagsVisible } from './PoolListFilters'
 import { PoolListTable } from './PoolListTable/PoolListTable'
 import { usePoolList } from './PoolListProvider'
 import { fNum } from '@/lib/shared/utils/numbers'
 
 export function PoolListLayout() {
   const { pools, loading, count } = usePoolList()
+  const isFilterVisible = useFilterTagsVisible()
+  const isMd = useBreakpointValue({ base: false, md: true })
+
+  const variants = {
+    visible: {
+      transform: isMd ? 'translateY(-40px)' : 'translateY(0)',
+    },
+    hidden: {
+      transform: 'translateY(0)',
+    },
+  }
 
   return (
     <VStack align="start" spacing="md" w="full">
@@ -15,16 +27,32 @@ export function PoolListLayout() {
         direction={{ base: 'column', md: 'row' }}
         w="full"
         justify="space-between"
-        align="start"
+        align={isFilterVisible ? 'end' : 'start'}
       >
-        <VStack align="start" w="full">
+        <VStack align="start" w="full" pb={{ base: 'sm', md: '0' }}>
           <HStack w="full">
-            <Heading as="h2" size="lg" variant="special">
-              Liquidity pools
-            </Heading>
-            <Heading size="md" variant="secondary" mt="1">
-              ({fNum('integer', count || 0)})
-            </Heading>
+            <Box position="relative" top="0">
+              <Box
+                as={motion.div}
+                position={{ base: 'relative', md: 'absolute' }}
+                top="0"
+                left="0"
+                transition="all 0.15s var(--ease-out-cubic)"
+                minW={{ base: 'auto', md: '270px' }}
+                willChange="transform"
+                variants={variants}
+                animate={isFilterVisible ? 'visible' : 'hidden'}
+              >
+                <HStack w="full">
+                  <Heading as="h2" size="lg" variant="special">
+                    Liquidity pools
+                  </Heading>
+                  <Heading size="md" variant="secondary" mt="1">
+                    ({fNum('integer', count || 0)})
+                  </Heading>
+                </HStack>
+              </Box>
+            </Box>
           </HStack>
           <FilterTags />
         </VStack>

--- a/lib/modules/pool/PoolList/PoolListLayout.tsx
+++ b/lib/modules/pool/PoolList/PoolListLayout.tsx
@@ -27,9 +27,9 @@ export function PoolListLayout() {
         direction={{ base: 'column', md: 'row' }}
         w="full"
         justify="space-between"
-        align={isFilterVisible ? 'end' : 'start'}
+        alignItems={isFilterVisible ? 'flex-end' : 'flex-start'}
       >
-        <VStack align="start" w="full" pb={{ base: 'sm', md: '0' }}>
+        <VStack align="start" w="full" pb={{ base: 'sm', md: '0' }} className="zzz" flex={1}>
           <HStack w="full">
             <Box position="relative" top="0">
               <Box
@@ -57,7 +57,11 @@ export function PoolListLayout() {
           <FilterTags />
         </VStack>
 
-        <Stack direction="row" w="full" align={{ base: 'end', sm: 'center' }}>
+        <Stack
+          direction="row"
+          w={{ base: 'full', md: 'auto' }}
+          align={{ base: 'end', sm: 'center' }}
+        >
           <PoolListFilters />
         </Stack>
       </Stack>

--- a/lib/modules/pool/PoolList/PoolListLayout.tsx
+++ b/lib/modules/pool/PoolList/PoolListLayout.tsx
@@ -29,7 +29,7 @@ export function PoolListLayout() {
         justify="space-between"
         alignItems={isFilterVisible ? 'flex-end' : 'flex-start'}
       >
-        <VStack align="start" w="full" pb={{ base: 'sm', md: '0' }} className="zzz" flex={1}>
+        <VStack align="start" w="full" pb={{ base: 'sm', md: '0' }} flex={1}>
           <HStack w="full">
             <Box position="relative" top="0">
               <Box

--- a/lib/shared/components/inputs/SearchInput.tsx
+++ b/lib/shared/components/inputs/SearchInput.tsx
@@ -31,7 +31,7 @@ export function SearchInput({
   const debouncedChangeHandler = useDebounce(changeHandler, defaultDebounceMs)
 
   return (
-    <InputGroup size="md" px="1">
+    <InputGroup size="md">
       <Input
         {...register(SEARCH)}
         id={SEARCH}


### PR DESCRIPTION
- Remove vertical jank
  - Position absolute title with translateY when FilterTags appear
  - AnimatePresence filter tags
- Remove vertical jank within popover
  - Move reset button inline with the Filter title in the popover to prevent jank within the popover when an item is selected. 
- Filter button improvements
  - Remove horizontal jank from filter button: Position absolute the numbered badge which appears within the Filter button, to remove it from the flow and keep the layout from shifting.
  - Use a semantic token for styling for easier customization for partners. 
- Enable the filter tags to go wider
  - The filter tags now take up all of the available space remaining after the search bar and filter button. This prevents more layout shifts, since wrapping now happens less frequently. 
  - Made the text within the filter tags more consistent (previously some were large text, and others medium sized text. 
- Minor padding improvements to the search bar on mobile