### PR TITLE
fix: avoid auto updates in used entered input in add proportional form

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.spec.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.spec.tsx
@@ -19,7 +19,7 @@ describe('calculates and sorts proportional human amounts in', () => {
     expect(humanAmountsIn).toEqual([
       {
         tokenAddress: usdcAddress,
-        humanAmount: '84.523645',
+        humanAmount: '100',
       },
       {
         tokenAddress: daiAddress,

--- a/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.spec.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.spec.tsx
@@ -11,7 +11,7 @@ describe('calculates and sorts proportional human amounts in', () => {
   it('given a new human amount for the first token (USDC)', () => {
     const humanAmountsIn = _calculateProportionalHumanAmountsIn({
       tokenAddress: usdcAddress,
-      humanAmount: '100',
+      humanAmount: '5',
       helpers,
       wethIsEth: false,
     })
@@ -19,11 +19,11 @@ describe('calculates and sorts proportional human amounts in', () => {
     expect(humanAmountsIn).toEqual([
       {
         tokenAddress: usdcAddress,
-        humanAmount: '100',
+        humanAmount: '5',
       },
       {
         tokenAddress: daiAddress,
-        humanAmount: '93.571836178433508978',
+        humanAmount: '4.678591808918857994',
       },
     ])
   })

--- a/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
@@ -171,10 +171,15 @@ export function _calculateProportionalHumanAmountsIn({
 }: Params): HumanTokenAmountWithAddress[] {
   const amountIn: InputAmount = helpers.toSdkInputAmounts([{ tokenAddress, humanAmount }])[0]
   const proportionalAmounts = calculateProportionalAmounts(helpers.poolStateWithBalances, amountIn)
-    .tokenAmounts.map(({ address, rawAmount, decimals }) => ({
-      tokenAddress: address,
-      humanAmount: formatUnits(rawAmount, decimals) as HumanAmount,
-    }))
+    .tokenAmounts.map(({ address, rawAmount, decimals }) => {
+      // Use the humanAmount entered by the user to avoid displaying rounding updates from calculateProportionalAmounts
+      if (address === tokenAddress) return { tokenAddress, humanAmount }
+
+      return {
+        tokenAddress: address,
+        humanAmount: formatUnits(rawAmount, decimals) as HumanAmount,
+      }
+    })
     // user updated token must be in the first place of the array because the Proportional handler always calculates bptOut based on the first position
     .sort(sortUpdatedTokenFirst(tokenAddress))
 


### PR DESCRIPTION
Entering 0.1 or 0.2 Cow was automatically updating the input to 0.099999999999999999 or 0.199999999999999999999999

**Before:** 
https://github.com/user-attachments/assets/023f4c02-a7b5-49b3-9d5b-fbf7ed235b5f

**After:** 
https://github.com/user-attachments/assets/88b64193-7d4a-4235-a7d1-143b006d959f

