### PR TITLE
chore: change gnosis default rpc url

### DIFF
--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -51,7 +51,7 @@ export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Base]: undefined,
   [GqlChain.Avalanche]: 'https://avalanche-c-chain-rpc.publicnode.com',
   [GqlChain.Fantom]: undefined,
-  [GqlChain.Gnosis]: undefined,
+  [GqlChain.Gnosis]: 'https://gnosis-rpc.publicnode.com',
   [GqlChain.Optimism]: undefined,
   [GqlChain.Polygon]: undefined,
   [GqlChain.Zkevm]: undefined,


### PR DESCRIPTION
Change default gnosis rpc url from  `https://rpc.gnosischain.com` to `https://gnosis-rpc.publicnode.com`
