### PR TITLE
fix: (re)calc tvl to get token weight percentages

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
+++ b/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Card, Divider, HStack, Heading, Skeleton, Stack, Text, VStack } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { usePool } from '../../PoolProvider'
 import { Address } from 'viem'
 import {
@@ -72,20 +72,22 @@ function CardContent({ totalLiquidity, displayTokens, chain }: CardContentProps)
 
 export function PoolComposition() {
   const { pool, chain, isLoading } = usePool()
-  const [totalLiquidity, setTotalLiquidity] = useState('')
   const { isMobile } = useBreakpoints()
-
-  useEffect(() => {
-    if (pool) {
-      setTotalLiquidity(pool.dynamicData.totalLiquidity)
-    }
-  }, [pool])
+  const { calcTvl } = useTokens()
 
   const displayTokens = pool.poolTokens.filter(token =>
     pool.displayTokens.find(
       (displayToken: GqlPoolTokenDisplay) => token.address === displayToken.address
     )
   ) as GqlPoolTokenDetail[]
+
+  const CardContentBlock = () => (
+    <CardContent
+      totalLiquidity={calcTvl(displayTokens, chain)}
+      displayTokens={displayTokens}
+      chain={chain}
+    />
+  )
 
   return (
     <Card>
@@ -100,18 +102,10 @@ export function PoolComposition() {
             Pool composition
           </Heading>
           {isMobile ? (
-            <CardContent
-              totalLiquidity={totalLiquidity}
-              displayTokens={displayTokens}
-              chain={chain}
-            />
+            <CardContentBlock />
           ) : (
             <Card variant="subSection" w="full">
-              <CardContent
-                totalLiquidity={totalLiquidity}
-                displayTokens={displayTokens}
-                chain={chain}
-              />
+              <CardContentBlock />
             </Card>
           )}
           {isMobile && <Divider />}

--- a/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
+++ b/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
@@ -4,11 +4,7 @@ import { Card, Divider, HStack, Heading, Skeleton, Stack, Text, VStack } from '@
 import React from 'react'
 import { usePool } from '../../PoolProvider'
 import { Address } from 'viem'
-import {
-  GqlChain,
-  GqlPoolTokenDetail,
-  GqlPoolTokenDisplay,
-} from '@/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlPoolTokenDetail } from '@/lib/shared/services/api/generated/graphql'
 import { useCurrency } from '@/lib/shared/hooks/useCurrency'
 import { fNum } from '@/lib/shared/utils/numbers'
 import { NoisyCard } from '@/lib/shared/components/containers/NoisyCard'
@@ -17,6 +13,7 @@ import { PoolWeightChart } from '../PoolWeightCharts/PoolWeightChart'
 import { useBreakpoints } from '@/lib/shared/hooks/useBreakpoints'
 import TokenRow from '@/lib/modules/tokens/TokenRow/TokenRow'
 import { useTokens } from '@/lib/modules/tokens/TokensProvider'
+import { getPoolDisplayTokens } from '../../pool.utils'
 
 type CardContentProps = {
   totalLiquidity: string
@@ -75,11 +72,7 @@ export function PoolComposition() {
   const { isMobile } = useBreakpoints()
   const { calcTotalUsdValue } = useTokens()
 
-  const displayTokens = pool.poolTokens.filter(token =>
-    pool.displayTokens.find(
-      (displayToken: GqlPoolTokenDisplay) => token.address === displayToken.address
-    )
-  ) as GqlPoolTokenDetail[]
+  const displayTokens = getPoolDisplayTokens(pool)
 
   const CardContentBlock = () => (
     <CardContent

--- a/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
+++ b/lib/modules/pool/PoolDetail/PoolComposition/PoolComposition.tsx
@@ -73,7 +73,7 @@ function CardContent({ totalLiquidity, displayTokens, chain }: CardContentProps)
 export function PoolComposition() {
   const { pool, chain, isLoading } = usePool()
   const { isMobile } = useBreakpoints()
-  const { calcTvl } = useTokens()
+  const { calcTotalUsdValue } = useTokens()
 
   const displayTokens = pool.poolTokens.filter(token =>
     pool.displayTokens.find(
@@ -83,7 +83,7 @@ export function PoolComposition() {
 
   const CardContentBlock = () => (
     <CardContent
-      totalLiquidity={calcTvl(displayTokens, chain)}
+      totalLiquidity={calcTotalUsdValue(displayTokens, chain)}
       displayTokens={displayTokens}
       chain={chain}
     />

--- a/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/PoolSnapshotValues.tsx
+++ b/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/PoolSnapshotValues.tsx
@@ -12,6 +12,7 @@ import { usePool } from '../../../PoolProvider'
 import { bn } from '@/lib/shared/utils/numbers'
 import MainAprTooltip from '@/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip'
 import { isCowAmmPool } from '../../../pool.helpers'
+import { getPoolDisplayTokens } from '../../../pool.utils'
 
 type PoolStatsValues = {
   totalLiquidity: string
@@ -22,7 +23,7 @@ type PoolStatsValues = {
 export function PoolSnapshotValues() {
   const { pool, chain } = usePool()
   const { toCurrency } = useCurrency()
-  const { priceFor, getToken } = useTokens()
+  const { priceFor, getToken, calcTotalUsdValue } = useTokens()
 
   const MemoizedMainAprTooltip = memo(MainAprTooltip)
 
@@ -48,7 +49,9 @@ export function PoolSnapshotValues() {
   const poolStatsValues: PoolStatsValues | undefined = useMemo(() => {
     if (pool) {
       return {
-        totalLiquidity: toCurrency(pool.dynamicData.totalLiquidity, { abbreviated: false }),
+        totalLiquidity: toCurrency(calcTotalUsdValue(getPoolDisplayTokens(pool), chain), {
+          abbreviated: false,
+        }),
         income24h: isCowAmmPool(pool.type)
           ? toCurrency(pool.dynamicData.surplus24h)
           : toCurrency(pool.dynamicData.fees24h),

--- a/lib/modules/pool/pool.utils.ts
+++ b/lib/modules/pool/pool.utils.ts
@@ -5,6 +5,7 @@ import {
   GqlPoolTokenDetail,
   GqlPoolType,
   GqlPoolAprItem,
+  GqlPoolTokenDisplay,
 } from '@/lib/shared/services/api/generated/graphql'
 import { invert } from 'lodash'
 import {
@@ -270,4 +271,12 @@ export function getAuraPoolLink(chainId: number, pid: string) {
 
 export function shouldHideSwapFee(poolType: GqlPoolType) {
   return poolType === GqlPoolType.CowAmm
+}
+
+export function getPoolDisplayTokens(pool: Pool) {
+  return pool.poolTokens.filter(token =>
+    pool.displayTokens.find(
+      (displayToken: GqlPoolTokenDisplay) => token.address === displayToken.address
+    )
+  ) as GqlPoolTokenDetail[]
 }

--- a/lib/modules/tokens/TokensProvider.tsx
+++ b/lib/modules/tokens/TokensProvider.tsx
@@ -8,6 +8,7 @@ import {
   GetTokensQuery,
   GetTokensQueryVariables,
   GqlChain,
+  GqlPoolTokenDetail,
   GqlToken,
 } from '@/lib/shared/services/api/generated/graphql'
 import { isSameAddress } from '@/lib/shared/utils/addresses'
@@ -130,6 +131,14 @@ export function _useTokens(
     []
   )
 
+  const calcTvl = useCallback((displayTokens: GqlPoolTokenDetail[], chain: GqlChain) => {
+    return displayTokens
+      .reduce((total, token) => {
+        return total.plus(bn(priceFor(token.address, chain)).times(token.balance))
+      }, bn(0))
+      .toString()
+  }, [])
+
   return {
     tokens,
     prices,
@@ -143,6 +152,7 @@ export function _useTokens(
     getTokensByTokenAddress,
     usdValueForToken,
     calcWeightForBalance,
+    calcTvl,
   }
 }
 

--- a/lib/modules/tokens/TokensProvider.tsx
+++ b/lib/modules/tokens/TokensProvider.tsx
@@ -131,7 +131,7 @@ export function _useTokens(
     []
   )
 
-  const calcTvl = useCallback((displayTokens: GqlPoolTokenDetail[], chain: GqlChain) => {
+  const calcTotalUsdValue = useCallback((displayTokens: GqlPoolTokenDetail[], chain: GqlChain) => {
     return displayTokens
       .reduce((total, token) => {
         return total.plus(bn(priceFor(token.address, chain)).times(token.balance))
@@ -152,7 +152,7 @@ export function _useTokens(
     getTokensByTokenAddress,
     usdValueForToken,
     calcWeightForBalance,
-    calcTvl,
+    calcTotalUsdValue,
   }
 }
 


### PR DESCRIPTION
when token prices update tvl is recalculated using the updated prices (token balance weights are already recalculated after token prices update)

![image](https://github.com/user-attachments/assets/4b9f2b28-4e7d-4c9d-b248-27a509a5d46e)