### PR TITLE
Fix pool balance discrepancy impacting proportional add/remove

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -41,13 +41,16 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
   const [wethIsEth, setWethIsEth] = useState(false)
   const [totalUSDValue, setTotalUSDValue] = useState('0')
 
-  const { pool, refetch: refetchPool } = usePool()
+  const { pool, refetch: refetchPool, isLoading, isLoadingOnchainData } = usePool()
   const { getToken, getNativeAssetToken, getWrappedNativeAssetToken, isLoadingTokenPrices } =
     useTokens()
   const { isConnected } = useUserAccount()
   const { hasValidationErrors } = useTokenInputsValidation()
 
-  const handler = useMemo(() => selectAddLiquidityHandler(pool), [pool.id])
+  const handler = useMemo(
+    () => selectAddLiquidityHandler(pool),
+    [pool.id, isLoadingOnchainData, isLoading]
+  )
 
   /**
    * Helper functions & variables

--- a/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -41,16 +41,13 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
   const [wethIsEth, setWethIsEth] = useState(false)
   const [totalUSDValue, setTotalUSDValue] = useState('0')
 
-  const { pool, refetch: refetchPool, isLoading, isLoadingOnchainData } = usePool()
+  const { pool, refetch: refetchPool, isLoading } = usePool()
   const { getToken, getNativeAssetToken, getWrappedNativeAssetToken, isLoadingTokenPrices } =
     useTokens()
   const { isConnected } = useUserAccount()
   const { hasValidationErrors } = useTokenInputsValidation()
 
-  const handler = useMemo(
-    () => selectAddLiquidityHandler(pool),
-    [pool.id, isLoadingOnchainData, isLoading]
-  )
+  const handler = useMemo(() => selectAddLiquidityHandler(pool), [pool.id, isLoading])
 
   /**
    * Helper functions & variables

--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -43,7 +43,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
   const [quoteAmountsOut, setQuoteAmountsOut] = useState<TokenAmount[]>([])
   const [quotePriceImpact, setQuotePriceImpact] = useState<number>()
 
-  const { pool, bptPrice, isLoading, isLoadingOnchainData } = usePool()
+  const { pool, bptPrice, isLoading } = usePool()
   const { getToken, usdValueForToken, getNativeAssetToken, getWrappedNativeAssetToken } =
     useTokens()
   const { isConnected } = useUserAccount()
@@ -63,7 +63,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
 
   const handler = useMemo(
     () => selectRemoveLiquidityHandler(pool, removalType),
-    [pool.id, removalType, isLoading, isLoadingOnchainData]
+    [pool.id, removalType, isLoading]
   )
 
   const totalUsdFromBprPrice = bn(humanBptIn).times(bptPrice).toFixed()

--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -43,7 +43,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
   const [quoteAmountsOut, setQuoteAmountsOut] = useState<TokenAmount[]>([])
   const [quotePriceImpact, setQuotePriceImpact] = useState<number>()
 
-  const { pool, bptPrice } = usePool()
+  const { pool, bptPrice, isLoading, isLoadingOnchainData } = usePool()
   const { getToken, usdValueForToken, getNativeAssetToken, getWrappedNativeAssetToken } =
     useTokens()
   const { isConnected } = useUserAccount()
@@ -63,7 +63,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
 
   const handler = useMemo(
     () => selectRemoveLiquidityHandler(pool, removalType),
-    [pool.id, removalType]
+    [pool.id, removalType, isLoading, isLoadingOnchainData]
   )
 
   const totalUsdFromBprPrice = bn(humanBptIn).times(bptPrice).toFixed()


### PR DESCRIPTION
The add/remove liquidity handler was only re-loading when the pool id changed, but this means that the handler gets set prior to the on chain data queries finishing. Because of this, all adds/removes are calculated using API data, which is very likely stale.

Added `isLoadingOnchainData` and `isLoading` to the dependencies so that it recreates the handler whenever data gets fetched.