### PR TITLE
fix: Subtract slippage from balances

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -49,10 +49,14 @@ import { BalAlert } from '@/lib/shared/components/alerts/BalAlert'
 
 // small wrapper to prevent out of context error
 export function AddLiquidityForm() {
+  const { pool } = usePool()
   const { validTokens } = useAddLiquidity()
 
   return (
-    <TokenBalancesProvider extTokens={validTokens}>
+    <TokenBalancesProvider
+      extTokens={validTokens}
+      subtractSlippage={requiresProportionalInput(pool.type)}
+    >
       <AddLiquidityMainForm />
     </TokenBalancesProvider>
   )

--- a/lib/modules/pool/actions/add-liquidity/form/useMaximumInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useMaximumInputs.tsx
@@ -26,7 +26,7 @@ export function useMaximumInputs() {
         ? wNativeAsset && balance.address !== wNativeAsset.address
         : nativeAsset && balance.address !== nativeAsset.address
     )
-  }, [wethIsEth, isBalancesLoading])
+  }, [wethIsEth, isBalancesLoading, balances])
 
   function handleMaximizeUserAmounts() {
     if (isMaximized) return setIsMaximized(false)

--- a/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
@@ -48,7 +48,7 @@ export function useProportionalInputs() {
         ? wNativeAsset && balance.address !== wNativeAsset.address
         : nativeAsset && balance.address !== nativeAsset.address
     )
-  }, [wethIsEth, isBalancesLoading])
+  }, [wethIsEth, isBalancesLoading, balances])
 
   function clearAmountsIn(changedAmount?: HumanTokenAmountWithAddress) {
     setHumanAmountsIn(

--- a/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
@@ -43,8 +43,6 @@ export class ProportionalAddLiquidityHandler implements AddLiquidityHandler {
       humanAmountIn
     )
 
-    bptAmount.rawAmount = bptAmount.rawAmount - 10n // Subtract 10 wei to ensure query doesn't fail when user maxes out balance.
-
     const addLiquidity = new AddLiquidity()
 
     const addLiquidityInput = this.constructSdkInput(humanAmountsIn, bptAmount)

--- a/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -12,6 +12,8 @@ import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { getNetworkConfig } from '@/lib/config/app.config'
 import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { exclNativeAssetFilter, nativeAssetFilter } from './token.helpers'
+import { HumanAmount, Slippage } from '@balancer/sdk'
+import { useUserSettings } from '../user/settings/UserSettingsProvider'
 
 const BALANCE_CACHE_TIME_MS = 30_000
 
@@ -22,13 +24,18 @@ export const TokenBalancesContext = createContext<UseTokenBalancesResponse | nul
  * If initTokens are provided the tokens state will be managed internally.
  * If extTokens are provided the tokens state will be managed externally.
  */
-export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[]) {
+export function _useTokenBalances(
+  initTokens?: GqlToken[],
+  extTokens?: GqlToken[],
+  subtractSlippage?: boolean
+) {
   if (!initTokens && !extTokens) throw new Error('initTokens or tokens must be provided')
   if (initTokens && extTokens) throw new Error('initTokens and tokens cannot be provided together')
 
   const [_tokens, _setTokens] = useState<GqlToken[]>(initTokens || [])
 
   const { userAddress } = useUserAccount()
+  const { slippage } = useUserSettings()
 
   const tokens = extTokens || _tokens
 
@@ -75,7 +82,13 @@ export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[
     .map((balance, index) => {
       const token = tokensExclNativeAsset[index]
       if (!token) return
-      const amount = balance.status === 'success' ? (balance.result as bigint) : 0n
+
+      let amount = balance.status === 'success' ? (balance.result as bigint) : 0n
+
+      if (subtractSlippage) {
+        // Subtract slippage from balance
+        amount = Slippage.fromPercentage(slippage as HumanAmount).applyTo(amount, -1)
+      }
 
       return {
         chainId,
@@ -88,14 +101,15 @@ export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[
     .filter(Boolean) as TokenAmount[]
 
   if (includesNativeAsset && nativeBalanceQuery.data) {
+    const nativeBalance = subtractSlippage
+      ? Slippage.fromPercentage(slippage as HumanAmount).applyTo(nativeBalanceQuery.data.value, -1)
+      : nativeBalanceQuery.data.value
+
     balances.push({
       chainId,
       address: networkConfig.tokens.nativeAsset.address,
-      amount: nativeBalanceQuery.data.value,
-      formatted: formatUnits(
-        nativeBalanceQuery.data.value,
-        networkConfig.tokens.nativeAsset.decimals
-      ),
+      amount: nativeBalance,
+      formatted: formatUnits(nativeBalance, networkConfig.tokens.nativeAsset.decimals),
       decimals: networkConfig.tokens.nativeAsset.decimals,
     })
   }
@@ -125,10 +139,19 @@ export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[
 type ProviderProps = PropsWithChildren<{
   initTokens?: GqlToken[]
   extTokens?: GqlToken[]
+  // This can be useful in cases where you want to leave a buffer,
+  // for example in forced proportional add liquidities where
+  // slippage means the tx will take more than your input.
+  subtractSlippage?: boolean
 }>
 
-export function TokenBalancesProvider({ initTokens, extTokens, children }: ProviderProps) {
-  const hook = _useTokenBalances(initTokens, extTokens)
+export function TokenBalancesProvider({
+  initTokens,
+  extTokens,
+  subtractSlippage,
+  children,
+}: ProviderProps) {
+  const hook = _useTokenBalances(initTokens, extTokens, subtractSlippage)
   return <TokenBalancesContext.Provider value={hook}>{children}</TokenBalancesContext.Provider>
 }
 


### PR DESCRIPTION
In forced proportional add-liquidity flows, subtract slippage from the user's token balances so that, if slippage does occur during the tx, it will always succeed.