### PR TITLE
fix: add explicit waitForTransactionReceipt timeouts

### DIFF
--- a/app/react-query.provider.tsx
+++ b/app/react-query.provider.tsx
@@ -30,7 +30,13 @@ export const queryClient = new QueryClient({
 
 queryClient.setDefaultOptions({
   queries: {
-    // avoids problems in simulation and build queries when the user navigates away from the page while waiting for a tx confirmation
+    /* Avoids problems in simulation and build queries when the user navigates away from the page while waiting for a tx confirmation.
+      Without this option, navigating to another tab and coming back was causing useRemoveLiquidityBuildCallDataQuery to be undefined leading to unexpected thrown errors.
+
+      This is equivalent to setting the old keepPreviousData: true option
+      More info:
+        https://github.com/TanStack/query/discussions/6460
+    */
     placeholderData: (prev: any) => prev,
   },
 })

--- a/app/react-query.provider.tsx
+++ b/app/react-query.provider.tsx
@@ -28,6 +28,13 @@ export const queryClient = new QueryClient({
   }),
 })
 
+queryClient.setDefaultOptions({
+  queries: {
+    // avoids problems in simulation and build queries when the user navigates away from the page while waiting for a tx confirmation
+    placeholderData: (prev: any) => prev,
+  },
+})
+
 export function ReactQueryClientProvider({ children }: { children: ReactNode | ReactNode[] }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/lib/modules/transactions/RecentTransactionsProvider.tsx
+++ b/lib/modules/transactions/RecentTransactionsProvider.tsx
@@ -14,6 +14,7 @@ import React, { ReactNode, createContext, useCallback, useEffect, useState } fro
 import { Hash } from 'viem'
 import { useConfig, usePublicClient } from 'wagmi'
 import { waitForTransactionReceipt } from 'wagmi/actions'
+import { getWaitForReceiptTimeout } from '../web3/contracts/wagmi-helpers'
 
 export type RecentTransactionsResponse = ReturnType<typeof _useRecentTransactions>
 export const TransactionsContext = createContext<RecentTransactionsResponse | null>(null)
@@ -85,6 +86,7 @@ export function _useRecentTransactions() {
           const receipt = await waitForTransactionReceipt(config, {
             hash: tx.hash,
             chainId: getChainId(tx.chain),
+            timeout: getWaitForReceiptTimeout(getChainId(tx.chain)),
           })
           if (receipt?.status === 'success') {
             updatePayload[tx.hash] = {

--- a/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -16,6 +16,7 @@ import { usdtAbi } from './abi/UsdtAbi'
 import { TransactionExecution, TransactionSimulation, WriteAbiMutability } from './contract.types'
 import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
 
 type Erc20Abi = typeof erc20Abi
 
@@ -70,6 +71,7 @@ export function useManagedErc20Transaction({
     chainId,
     hash: txHash,
     confirmations: minConfirmations,
+    timeout: getWaitForReceiptTimeout(chainId),
   })
 
   const bundle = {

--- a/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -17,6 +17,7 @@ import { useNetworkConfig } from '@/lib/config/useNetworkConfig'
 import { useRecentTransactions } from '../../transactions/RecentTransactionsProvider'
 import { mainnet } from 'viem/chains'
 import { useTxHash } from '../safe.hooks'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
 
 export type ManagedSendTransactionInput = {
   labels: TransactionLabels
@@ -40,6 +41,7 @@ export function useManagedSendTransaction({
     query: {
       enabled: !!txConfig && !shouldChangeNetwork,
       meta: gasEstimationMeta,
+      refetchOnWindowFocus: false,
     },
   })
 
@@ -58,6 +60,7 @@ export function useManagedSendTransaction({
     chainId,
     hash: txHash,
     confirmations: minConfirmations,
+    timeout: getWaitForReceiptTimeout(chainId),
   })
 
   const bundle = {
@@ -93,11 +96,6 @@ export function useManagedSendTransaction({
 
   useEffect(() => {
     if (transactionStatusQuery.error) {
-      captureWagmiExecutionError(transactionStatusQuery.error, 'Error in useWaitForTransaction', {
-        chainId,
-        txHash,
-      })
-
       if (txHash) {
         updateTrackedTransaction(txHash, {
           status: 'timeout',

--- a/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -14,6 +14,7 @@ import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
 import { captureWagmiExecutionError } from '@/lib/shared/utils/query-errors'
 import { useTxHash } from '../safe.hooks'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
 
 type IAbiMap = typeof AbiMap
 type AbiMapKey = keyof typeof AbiMap
@@ -63,6 +64,7 @@ export function useManagedTransaction({
     chainId,
     hash: txHash,
     confirmations: minConfirmations,
+    timeout: getWaitForReceiptTimeout(chainId),
   })
 
   const bundle = {

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -1,6 +1,7 @@
 // Helpers for wagmi transactions
 import { Address } from 'viem'
 import { TransactionBundle } from './contract.types'
+import { polygon } from 'viem/chains'
 
 export function getHashFromTransaction(transactionBundle?: TransactionBundle): Address | undefined {
   if (!transactionBundle) return
@@ -15,4 +16,18 @@ export function isValidUserAddress(userAddress?: Address) {
   if (!userAddress) return false
   if (userAddress === noUserAddress) return false
   return true
+}
+
+/*
+  Returns timeout to be used in useWaitForTransactionReceipt options
+  By default all react queries retry 3 times
+  More info: https://tanstack.com/query/v5/docs/framework/react/guides/query-retries
+ */
+export function getWaitForReceiptTimeout(chainId: number) {
+  console.log({ chainId })
+  // In polygon there will be 3 retries of 25 seconds until we throw the timeout error
+  if (chainId === polygon.id) return 25_000
+
+  // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
+  return 15_000
 }

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -2,6 +2,7 @@
 import { Address } from 'viem'
 import { TransactionBundle } from './contract.types'
 import { polygon } from 'viem/chains'
+import { secs } from '@/lib/shared/utils/time'
 
 export function getHashFromTransaction(transactionBundle?: TransactionBundle): Address | undefined {
   if (!transactionBundle) return
@@ -25,8 +26,8 @@ export function isValidUserAddress(userAddress?: Address) {
  */
 export function getWaitForReceiptTimeout(chainId: number) {
   // In polygon there will be 3 retries of 25 seconds until we throw the timeout error
-  if (chainId === polygon.id) return 25_000
+  if (chainId === polygon.id) return secs(25).toMs()
 
   // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
-  return 15_000
+  return secs(15).toMs()
 }

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -24,9 +24,8 @@ export function isValidUserAddress(userAddress?: Address) {
   More info: https://tanstack.com/query/v5/docs/framework/react/guides/query-retries
  */
 export function getWaitForReceiptTimeout(chainId: number) {
-  console.log({ chainId })
   // In polygon there will be 3 retries of 25 seconds until we throw the timeout error
-  if (chainId === polygon.id) return 25_000
+  if (chainId === polygon.id) return 2_000
 
   // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
   return 15_000

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -25,7 +25,7 @@ export function isValidUserAddress(userAddress?: Address) {
  */
 export function getWaitForReceiptTimeout(chainId: number) {
   // In polygon there will be 3 retries of 25 seconds until we throw the timeout error
-  if (chainId === polygon.id) return 2_000
+  if (chainId === polygon.id) return 25_000
 
   // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
   return 15_000


### PR DESCRIPTION
We found random timeout issues when passing undefined to wagmi's `timeout` option in `waitForTransactionReceipt`:  

https://github.com/wevm/viem/discussions/1351

Using an explicit timeout option seems to work better. 

This PR uses 25 seconds for polygon and 15 seconds for other chains. Given that react query runs 3 retries by default, we will wait a max of: 

polygon: 25 x 4 = 100 seconds
others: 15 x 4 = 60 seconds

before showing this error in the UI and capturing the error in sentry:
<img width="398" alt="timeoutError" src="https://github.com/user-attachments/assets/83f93ed3-72fc-4017-9740-3d29a0c90880">


