### PR TITLE
chore: remove unbalanced priceImpact amount rounding (now that SDK related issue is fixed)

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
@@ -10,11 +10,7 @@ import {
   Slippage,
 } from '@balancer/sdk'
 import { Pool } from '../../../PoolProvider'
-import {
-  LiquidityActionHelpers,
-  areEmptyAmounts,
-  roundDecimals,
-} from '../../LiquidityActionHelpers'
+import { LiquidityActionHelpers, areEmptyAmounts } from '../../LiquidityActionHelpers'
 import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { SdkBuildAddLiquidityInput, SdkQueryAddLiquidityOutput } from '../add-liquidity.types'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
@@ -50,8 +46,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
       return 0
     }
 
-    // trims amounts in to 10 decimals to workaround an SDK error in price impact calculation when proportional amounts have more than 10 decimals
-    const addLiquidityInput = this.constructSdkInput(roundDecimals(humanAmountsIn))
+    const addLiquidityInput = this.constructSdkInput(humanAmountsIn)
 
     const priceImpactABA: PriceImpactAmount = await PriceImpact.addLiquidityUnbalanced(
       addLiquidityInput,


### PR DESCRIPTION
It looks like the issue is fixed in the SDK so the rounding workaround is not needed anymore. 
https://github.com/balancer/b-sdk/issues/326#issuecomment-2286372869

Closes https://github.com/balancer/frontend-v3/issues/665

