### PR TITLE
fix: receipt states for Add Liquidity

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquidityModal.tsx
@@ -16,6 +16,8 @@ import { TransactionModalHeader } from '@/lib/shared/components/modals/Transacti
 import { useResetStepIndexOnOpen } from '../../useResetStepIndexOnOpen'
 import { useOnUserAccountChanged } from '@/lib/modules/web3/useOnUserAccountChanged'
 import { AddLiquiditySummary } from './AddLiquiditySummary'
+import { useAddLiquidityReceipt } from '@/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
+import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 
 type Props = {
   isOpen: boolean
@@ -34,8 +36,14 @@ export function AddLiquidityModal({
   const initialFocusRef = useRef(null)
   const { transactionSteps, addLiquidityTxHash, hasQuoteContext, setInitialHumanAmountsIn } =
     useAddLiquidity()
-  const { pool } = usePool()
+  const { pool, chain } = usePool()
   const { redirectToPoolPage } = usePoolRedirect(pool)
+  const { userAddress } = useUserAccount()
+  const receiptProps = useAddLiquidityReceipt({
+    chain,
+    txHash: addLiquidityTxHash,
+    userAddress,
+  })
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
@@ -71,10 +79,11 @@ export function AddLiquidityModal({
           timeout={<AddLiquidityTimeout />}
           txHash={addLiquidityTxHash}
           chain={pool.chain}
+          isReceiptReady={receiptProps.isReceiptReady}
         />
         <ModalCloseButton />
         <ModalBody>
-          <AddLiquiditySummary />
+          <AddLiquiditySummary {...receiptProps} />
         </ModalBody>
         <ActionModalFooter
           isSuccess={!!addLiquidityTxHash}

--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
@@ -10,7 +10,7 @@ import { QuoteBptOut, ReceiptBptOut } from './BptOut'
 import { TokenRowGroup } from '@/lib/modules/tokens/TokenRow/TokenRowGroup'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
-import { useAddLiquidityReceipt } from '@/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
+import { AddLiquidityReceiptResult } from '@/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
 import { BalAlert } from '@/lib/shared/components/alerts/BalAlert'
 import { StakingOptions } from './StakingOptions'
 import { isVebalPool } from '../../../pool.helpers'
@@ -18,7 +18,12 @@ import { VebalRedirectModal } from '@/lib/modules/vebal/VebalRedirectModal'
 import { AnimateHeightChange } from '@/lib/shared/components/modals/AnimatedModalBody'
 import { CardPopAnim } from '@/lib/shared/components/animations/CardPopAnim'
 
-export function AddLiquiditySummary() {
+export function AddLiquiditySummary({
+  isLoading: isLoadingReceipt,
+  error,
+  sentTokens,
+  receivedBptUnits,
+}: AddLiquidityReceiptResult) {
   const {
     totalUSDValue,
     simulationQuery,
@@ -29,33 +34,25 @@ export function AddLiquiditySummary() {
     addLiquidityTxHash,
     addLiquidityTxSuccess,
   } = useAddLiquidity()
-  const { pool, chain } = usePool()
+  const { pool } = usePool()
   const { isMobile } = useBreakpoints()
   const { userAddress, isLoading: isUserAddressLoading } = useUserAccount()
   const vebalRedirectModal = useDisclosure()
-  const {
-    isLoading: isLoadingReceipt,
-    error,
-    sentTokens,
-    receivedBptUnits,
-  } = useAddLiquidityReceipt({
-    chain,
-    txHash: addLiquidityTxHash,
-    userAddress,
-  })
 
   // Order amountsIn like the form inputs which uses the tokens array.
   const amountsIn = tokens
     .map(token => humanAmountsIn.find(amount => amount.tokenAddress === token?.address))
     .filter(Boolean) as HumanTokenAmountWithAddress[]
 
+  const shouldShowErrors = hasQuoteContext ? addLiquidityTxSuccess : addLiquidityTxHash
+
   if (!isUserAddressLoading && !userAddress) {
     return <BalAlert status="warning" content="User is not connected" />
   }
-  if (addLiquidityTxSuccess && error) {
+  if (shouldShowErrors && error) {
     return <BalAlert status="warning" content="We were unable to find this transaction hash" />
   }
-  if (addLiquidityTxSuccess && !isLoadingReceipt && !sentTokens.length) {
+  if (shouldShowErrors && !isLoadingReceipt && !sentTokens.length) {
     return (
       <BalAlert
         status="warning"
@@ -66,6 +63,11 @@ export function AddLiquiditySummary() {
 
   const shouldShowReceipt = addLiquidityTxHash && !isLoadingReceipt && sentTokens.length > 0
 
+  const isLoadingSentTokens = () => {
+    if (hasQuoteContext) return shouldShowReceipt && isLoadingReceipt
+    return isLoadingReceipt
+  }
+
   return (
     <AnimateHeightChange spacing="sm">
       {isMobile && hasQuoteContext && (
@@ -74,11 +76,11 @@ export function AddLiquiditySummary() {
 
       <Card variant="modalSubSection">
         <TokenRowGroup
-          label={shouldShowReceipt ? 'You added' : "You're adding"}
+          label={shouldShowReceipt || !hasQuoteContext ? 'You added' : "You're adding"}
           amounts={shouldShowReceipt ? sentTokens : amountsIn}
           totalUSDValue={totalUSDValue}
           chain={pool.chain}
-          isLoading={shouldShowReceipt ? isLoadingReceipt : false}
+          isLoading={isLoadingSentTokens()}
         />
       </Card>
 
@@ -86,7 +88,7 @@ export function AddLiquiditySummary() {
         {shouldShowReceipt ? (
           <ReceiptBptOut actualBptOut={receivedBptUnits} isLoading={isLoadingReceipt} />
         ) : (
-          <QuoteBptOut />
+          <QuoteBptOut isLoading={isLoadingSentTokens()} />
         )}
       </Card>
 
@@ -113,7 +115,7 @@ export function AddLiquiditySummary() {
             </Card>
           )}
         </CardPopAnim>
-      ) : (
+      ) : hasQuoteContext ? (
         <CardPopAnim key="price-impact-details">
           <Card variant="modalSubSection">
             <VStack align="start" spacing="sm">
@@ -125,7 +127,7 @@ export function AddLiquiditySummary() {
             </VStack>
           </Card>
         </CardPopAnim>
-      )}
+      ) : null}
     </AnimateHeightChange>
   )
 }

--- a/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
@@ -63,7 +63,7 @@ export function AddLiquiditySummary({
 
   const shouldShowReceipt = addLiquidityTxHash && !isLoadingReceipt && sentTokens.length > 0
 
-  const isLoadingSentTokens = () => {
+  const isLoadingTokenData = () => {
     if (hasQuoteContext) return shouldShowReceipt && isLoadingReceipt
     return isLoadingReceipt
   }
@@ -80,7 +80,7 @@ export function AddLiquiditySummary({
           amounts={shouldShowReceipt ? sentTokens : amountsIn}
           totalUSDValue={totalUSDValue}
           chain={pool.chain}
-          isLoading={isLoadingSentTokens()}
+          isLoading={isLoadingTokenData()}
         />
       </Card>
 
@@ -88,7 +88,7 @@ export function AddLiquiditySummary({
         {shouldShowReceipt ? (
           <ReceiptBptOut actualBptOut={receivedBptUnits} isLoading={isLoadingReceipt} />
         ) : (
-          <QuoteBptOut isLoading={isLoadingSentTokens()} />
+          <QuoteBptOut isLoading={isLoadingTokenData()} />
         )}
       </Card>
 

--- a/lib/modules/pool/actions/add-liquidity/modal/BptOut.tsx
+++ b/lib/modules/pool/actions/add-liquidity/modal/BptOut.tsx
@@ -42,7 +42,7 @@ export function ReceiptBptOut({
   )
 }
 
-export function QuoteBptOut({ label }: { label?: string }) {
+export function QuoteBptOut({ label, isLoading = false }: { label?: string; isLoading?: boolean }) {
   const { simulationQuery } = useAddLiquidity()
   const bptOut = simulationQuery?.data?.bptOut
   const bptOutUnits = bptOut ? formatUnits(bptOut.amount, BPT_DECIMALS) : '0'
@@ -56,5 +56,5 @@ export function QuoteBptOut({ label }: { label?: string }) {
     ? 'You will get'
     : 'You will get (if no slippage)'
 
-  return <BptRow label={_label} bptAmount={bptOutUnits} pool={pool} />
+  return <BptRow label={_label} bptAmount={bptOutUnits} pool={pool} isLoading={isLoading} />
 }

--- a/lib/modules/tokens/TokenRow/BptRow.tsx
+++ b/lib/modules/tokens/TokenRow/BptRow.tsx
@@ -19,7 +19,7 @@ export function BptRow({
   return (
     <VStack align="start" spacing="md">
       <HStack justify="space-between" w="full">
-        <Text color="grayText">{label}</Text>
+        {!isLoading && <Text color="grayText">{label}</Text>}
         {rightLabel && <Text color="grayText">{rightLabel}</Text>}
       </HStack>
       <TokenRow

--- a/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.ts
+++ b/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.ts
@@ -17,6 +17,7 @@ type BaseReceiptProps = {
 }
 
 export type ReceiptProps = BaseReceiptProps & { parseReceipt: ParseReceipt }
+export type AddLiquidityReceiptResult = ReturnType<typeof useAddLiquidityReceipt>
 
 export function useAddLiquidityReceipt(props: BaseReceiptProps) {
   const result = useTxReceipt({ ...props, parseReceipt: parseAddLiquidityReceipt })
@@ -25,6 +26,7 @@ export function useAddLiquidityReceipt(props: BaseReceiptProps) {
 
   return {
     ...result,
+    isReceiptReady: !!data,
     sentTokens: data?.sentTokens || [],
     receivedBptUnits: data?.receivedBptUnits || '0',
   }

--- a/lib/shared/components/modals/TransactionModalHeader.tsx
+++ b/lib/shared/components/modals/TransactionModalHeader.tsx
@@ -11,11 +11,14 @@ export function TransactionModalHeader({
   timeout,
   txHash,
   chain,
+  // true by default for flows that do not have a receipt
+  isReceiptReady = true,
 }: {
   label: string
   txHash?: Hash
   chain: GqlChain
   timeout?: React.ReactNode
+  isReceiptReady?: boolean
 }) {
   const { getBlockExplorerTxUrl } = useBlockExplorer(chain)
 
@@ -23,7 +26,12 @@ export function TransactionModalHeader({
     <ModalHeader>
       <HStack justify="space-between" w="full" pr="lg">
         <AnimatePresence mode="wait" initial={false}>
-          {txHash ? (
+          {!txHash ? (
+            <>
+              <span>{label}</span>
+              {timeout || null}
+            </>
+          ) : isReceiptReady ? (
             <HStack spacing="md">
               <motion.div
                 initial={{ opacity: 0, scale: 0 }}
@@ -52,12 +60,7 @@ export function TransactionModalHeader({
                 </VStack>
               </motion.div>
             </HStack>
-          ) : (
-            <>
-              <span>{label}</span>
-              {timeout || null}
-            </>
-          )}
+          ) : null}
         </AnimatePresence>
       </HStack>
     </ModalHeader>


### PR DESCRIPTION
**TODO**: the same fix must be applied for removes and swaps.

Opening historical receipts from a tx url was broken. 

This PR on top of receiptLogs PR is an initial improvement to make it work. We can make it better but I would do it in a different PR when it this is a priority.

Now when we open a receipt that takes time to be loaded (artificial delay added  for this demo):

https://github.com/user-attachments/assets/385543e9-221c-47ac-ab02-8a8f105181b7

It also fixes the state where the user tries to load an historic receipt connected with a different account than the one that created the transaction:

<img width="614" alt="Screenshot 2024-08-14 at 18 54 27" src="https://github.com/user-attachments/assets/21f01fde-b44c-4d84-8459-bb9a5f16e253">



