### PR TITLE
fix: pool events table bugs

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
+++ b/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
@@ -4,7 +4,7 @@
 import * as echarts from 'echarts/core'
 import { useRef } from 'react'
 import { useParams } from 'next/navigation'
-import { differenceInDays, format } from 'date-fns'
+import { secondsToMilliseconds, differenceInDays, format } from 'date-fns'
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import EChartsReactCore from 'echarts-for-react/lib/core'
 import { ChainSlug, slugToChainMap } from '../../pool.utils'
@@ -65,7 +65,11 @@ const getDefaultPoolActivityChartOptions = (
         formatter: (value: number) =>
           format(
             new Date(value * 1000),
-            `MMM d${differenceInDays(maxDate, minDate) < 1 ? ' HH:mm' : ''}`
+            `MMM d${
+              differenceInDays(secondsToMilliseconds(maxDate), secondsToMilliseconds(minDate)) < 1
+                ? ' HH:mm'
+                : ''
+            }`
           ),
         color: theme.semanticTokens.colors.font.primary[colorMode],
         opacity: 0.5,

--- a/lib/shared/components/pagination/getPaginationProps.ts
+++ b/lib/shared/components/pagination/getPaginationProps.ts
@@ -12,7 +12,7 @@ export function getPaginationProps(
       : Math.floor(totalRowCount / pagination.pageSize) + 1 // add extra page to account for remainder
 
   const canPreviousPage = pagination.pageIndex - 1 > -1
-  const canNextPage = pagination.pageIndex + 1 <= totalPageCount
+  const canNextPage = pagination.pageIndex + 1 < totalPageCount
   const currentPageNumber = pagination.pageIndex + 1
   const pageSize = pagination.pageSize
 


### PR DESCRIPTION
fixes #1000

- fixes only showing hours on chart xaxis when all events are within the last 24 hours

- fixes being able to click on 'next page' when already at the last page of the table