### PR TITLE
fix: Display loading states if price impact is loading

### DIFF
--- a/lib/modules/pool/actions/PoolActionsPriceImpactDetails.tsx
+++ b/lib/modules/pool/actions/PoolActionsPriceImpactDetails.tsx
@@ -1,6 +1,6 @@
 import { NumberText } from '@/lib/shared/components/typography/NumberText'
 import { fNum, bn } from '@/lib/shared/utils/numbers'
-import { HStack, VStack, Text, Tooltip, Icon, Box } from '@chakra-ui/react'
+import { HStack, VStack, Text, Tooltip, Icon, Box, Skeleton } from '@chakra-ui/react'
 import { usePriceImpact } from '@/lib/modules/price-impact/PriceImpactProvider'
 import { useUserSettings } from '@/lib/modules/user/settings/UserSettingsProvider'
 import { useCurrency } from '@/lib/shared/hooks/useCurrency'
@@ -14,12 +14,14 @@ interface PoolActionsPriceImpactDetailsProps {
   bptAmount: bigint | undefined
   totalUSDValue: string
   isAddLiquidity?: boolean
+  isLoading?: boolean
 }
 
 export function PoolActionsPriceImpactDetails({
   bptAmount,
   totalUSDValue,
   isAddLiquidity = false,
+  isLoading = false,
 }: PoolActionsPriceImpactDetailsProps) {
   const { slippage } = useUserSettings()
   const { toCurrency } = useCurrency()
@@ -44,7 +46,9 @@ export function PoolActionsPriceImpactDetails({
       <HStack justify="space-between" w="full">
         <Text color="grayText">Price impact</Text>
         <HStack>
-          {priceImpactLevel === 'unknown' ? (
+          {isLoading ? (
+            <Skeleton w="40px" h="16px" />
+          ) : priceImpactLevel === 'unknown' ? (
             <Text>Unknown</Text>
           ) : (
             <NumberText color={priceImpactColor}>
@@ -71,9 +75,13 @@ export function PoolActionsPriceImpactDetails({
       <HStack justify="space-between" w="full">
         <Text color="grayText">Max slippage</Text>
         <HStack>
-          <NumberText color="grayText">
-            {toCurrency(maxSlippageUsd, { abbreviated: false })} ({fNum('slippage', slippage)})
-          </NumberText>
+          {isLoading ? (
+            <Skeleton w="40px" h="16px" />
+          ) : (
+            <NumberText color="grayText">
+              {toCurrency(maxSlippageUsd, { abbreviated: false })} ({fNum('slippage', slippage)})
+            </NumberText>
+          )}
           <Tooltip
             label="Slippage occurs when market conditions change between the time your order is
                 submitted and the time it gets executed on-chain. Slippage tolerance is the
@@ -88,9 +96,15 @@ export function PoolActionsPriceImpactDetails({
         <Text color="grayText">Share of pool</Text>
         <HStack>
           <HStack gap="0.5">
-            <NumberText color="grayText">{fNum('sharePercent', currentShareOfPool)}</NumberText>
-            <Icon as={ArrowRight} color="grayText" />
-            <NumberText color="grayText">{fNum('sharePercent', futureShareOfPool)}</NumberText>
+            {isLoading ? (
+              <Skeleton w="40px" h="16px" />
+            ) : (
+              <>
+                <NumberText color="grayText">{fNum('sharePercent', currentShareOfPool)}</NumberText>
+                <Icon as={ArrowRight} color="grayText" />
+                <NumberText color="grayText">{fNum('sharePercent', futureShareOfPool)}</NumberText>
+              </>
+            )}
           </HStack>
           <Tooltip
             label="The percentage of the pool that you will own after this transaction."

--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   GridItem,
   HStack,
+  Skeleton,
   Text,
   Tooltip,
   VStack,
@@ -90,10 +91,13 @@ function AddLiquidityMainForm() {
     setPriceImpact(priceImpactQuery.data)
   }, [priceImpactQuery.data])
 
-  const priceImpactLabel =
-    priceImpact !== undefined && priceImpact !== null ? fNum('priceImpact', priceImpact) : '-'
+  const hasPriceImpact = priceImpact !== undefined && priceImpact !== null
+  const priceImpactLabel = hasPriceImpact ? fNum('priceImpact', priceImpact) : '-'
 
   const weeklyYield = calcPotentialYieldFor(pool, totalUSDValue)
+
+  const isLoading = simulationQuery.isLoading || priceImpactQuery.isLoading
+  const isFetching = simulationQuery.isFetching || priceImpactQuery.isFetching
 
   const onModalOpen = async () => {
     previewModalDisclosure.onOpen()
@@ -174,9 +178,13 @@ function AddLiquidityMainForm() {
                   <Text variant="secondary" fontSize="sm" color="font.secondary">
                     Price impact:{' '}
                   </Text>
-                  <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
-                    {priceImpactLabel}
-                  </Text>
+                  {isFetching ? (
+                    <Skeleton w="40px" h="16px" />
+                  ) : (
+                    <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
+                      {priceImpactLabel}
+                    </Text>
+                  )}
                 </HStack>
               }
               accordionPanelComponent={
@@ -184,6 +192,7 @@ function AddLiquidityMainForm() {
                   totalUSDValue={totalUSDValue}
                   bptAmount={simulationQuery.data?.bptOut.amount}
                   isAddLiquidity
+                  isLoading={isFetching}
                 />
               }
             />
@@ -228,7 +237,7 @@ function AddLiquidityMainForm() {
                 w="full"
                 size="lg"
                 isDisabled={isDisabled}
-                isLoading={simulationQuery.isLoading || priceImpactQuery.isLoading}
+                isLoading={isLoading}
                 onClick={() => !isDisabled && onModalOpen()}
               >
                 Next

--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -7,7 +7,17 @@ import ButtonGroup, {
 } from '@/lib/shared/components/btns/button-group/ButtonGroup'
 import { InputWithSlider } from '@/lib/shared/components/inputs/InputWithSlider/InputWithSlider'
 import { fNum } from '@/lib/shared/utils/numbers'
-import { Box, Button, Card, CardHeader, HStack, Text, Tooltip, VStack } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  HStack,
+  Skeleton,
+  Text,
+  Tooltip,
+  VStack,
+} from '@chakra-ui/react'
 import { useEffect, useRef, useState } from 'react'
 import { RemoveLiquidityModal } from '../modal/RemoveLiquidityModal'
 import { useRemoveLiquidity } from '../RemoveLiquidityProvider'
@@ -64,8 +74,10 @@ export function RemoveLiquidityForm() {
     setPriceImpact(priceImpactQuery.data)
   }, [priceImpactQuery.data])
 
-  const priceImpactLabel =
-    priceImpact !== undefined && priceImpact !== null ? fNum('priceImpact', priceImpact) : '-' // If it's 0 we want to display 0.
+  const hasPriceImpact = priceImpact !== undefined && priceImpact !== null
+  const priceImpactLabel = hasPriceImpact ? fNum('priceImpact', priceImpact) : '-' // If it's 0 we want to display 0.
+
+  const isFetching = simulationQuery.isFetching || priceImpactQuery.isFetching
 
   function toggleTab(option: ButtonGroupOption) {
     setActiveTab(option)
@@ -145,15 +157,20 @@ export function RemoveLiquidityForm() {
                     <Text variant="secondary" fontSize="sm" color="font.secondary">
                       Price impact:{' '}
                     </Text>
-                    <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
-                      {priceImpactLabel}
-                    </Text>
+                    {isFetching ? (
+                      <Skeleton w="40px" h="16px" />
+                    ) : (
+                      <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
+                        {priceImpactLabel}
+                      </Text>
+                    )}
                   </HStack>
                 }
                 accordionPanelComponent={
                   <PoolActionsPriceImpactDetails
                     totalUSDValue={totalUSDValue}
                     bptAmount={BigInt(parseUnits(quoteBptIn, 18))}
+                    isLoading={isFetching}
                   />
                 }
                 isDisabled={priceImpactQuery.isLoading && !priceImpactQuery.isSuccess}


### PR DESCRIPTION
There is a kind of UX bug in add/remove flows where when you change input values the price impact stays the same until the new result is loaded, then it updates the UI value. This is dangerous as the user could think that the price impact is lower than expected by clicking on next too quickly. This PR simply replaces the price impact values with loading states when the query is fetching.