### PR TITLE
feat: show Safe App info alert when using Safe Account via WC

### DIFF
--- a/app/(app)/debug/alerts/page.tsx
+++ b/app/(app)/debug/alerts/page.tsx
@@ -38,6 +38,17 @@ export default function Page() {
         learnMoreLink="https://balancer.fi"
         status="error"
       />
+      <BalAlert
+        content={
+          <BalAlertContent
+            title="Info alert"
+            description="With description in the next line (forceColumnMode)"
+            forceColumnMode
+          ></BalAlertContent>
+        }
+        status="info"
+      />
+
       <GenericError
         error={new TestError(exceptionName, exceptionMessage)}
         maxWidth="500"

--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -46,6 +46,7 @@ import { cannotCalculatePriceImpactError } from '@/lib/modules/price-impact/pric
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { ConnectWallet } from '@/lib/modules/web3/ConnectWallet'
 import { BalAlert } from '@/lib/shared/components/alerts/BalAlert'
+import { SafeAppAlert } from '@/lib/shared/components/alerts/SafeAppAlert'
 
 // small wrapper to prevent out of context error
 export function AddLiquidityForm() {
@@ -155,6 +156,7 @@ function AddLiquidityMainForm() {
           {hasNoLiquidity(pool) && (
             <BalAlert status="warning" content="You cannot add because the pool has no liquidity" />
           )}
+          <SafeAppAlert />
           {supportsProportionalAdds(pool) ? (
             <TokenInputsWithAddable
               tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()}

--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -23,6 +23,7 @@ import { usePriceImpact } from '@/lib/modules/price-impact/PriceImpactProvider'
 import { parseUnits } from 'viem'
 import { SimulationError } from '@/lib/shared/components/errors/SimulationError'
 import { InfoIcon } from '@/lib/shared/components/icons/InfoIcon'
+import { SafeAppAlert } from '@/lib/shared/components/alerts/SafeAppAlert'
 
 const TABS: ButtonGroupOption[] = [
   {
@@ -105,6 +106,7 @@ export function RemoveLiquidityForm() {
             </HStack>
           </CardHeader>
           <VStack spacing="md" align="start">
+            <SafeAppAlert />
             {!requiresProportionalInput(pool.type) && (
               <HStack>
                 <ButtonGroup

--- a/lib/modules/pool/actions/stake/StakeForm.tsx
+++ b/lib/modules/pool/actions/stake/StakeForm.tsx
@@ -6,6 +6,7 @@ import { useRef } from 'react'
 import { StakeModal } from './StakeModal'
 import { StakePreview } from './StakePreview'
 import { useModalWithPoolRedirect } from '../../useModalWithPoolRedirect'
+import { SafeAppAlert } from '@/lib/shared/components/alerts/SafeAppAlert'
 
 export function StakeForm() {
   const { isDisabled, disabledReason, isLoading, stakeTxHash, pool } = useStake()
@@ -17,6 +18,7 @@ export function StakeForm() {
       <Card>
         <CardHeader>Stake for rewards</CardHeader>
         <CardBody>
+          <SafeAppAlert />
           <StakePreview />
         </CardBody>
         <CardFooter>

--- a/lib/modules/pool/actions/unstake/UnstakeForm.tsx
+++ b/lib/modules/pool/actions/unstake/UnstakeForm.tsx
@@ -6,6 +6,7 @@ import { useUnstake } from './UnstakeProvider'
 import { UnstakePreview } from './UnstakePreview'
 import { UnstakeModal } from './UnstakeModal'
 import { useModalWithPoolRedirect } from '../../useModalWithPoolRedirect'
+import { SafeAppAlert } from '@/lib/shared/components/alerts/SafeAppAlert'
 
 export function UnstakeForm() {
   const nextBtn = useRef(null)
@@ -19,6 +20,7 @@ export function UnstakeForm() {
       <Card>
         <CardHeader>Claim & Unstake</CardHeader>
         <CardBody>
+          <SafeAppAlert />
           <UnstakePreview />
         </CardBody>
         <CardFooter>

--- a/lib/modules/swap/SwapForm.tsx
+++ b/lib/modules/swap/SwapForm.tsx
@@ -36,6 +36,7 @@ import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
 import { parseSwapError } from './swap.helpers'
 import { useUserAccount } from '../web3/UserAccountProvider'
 import { ConnectWallet } from '../web3/ConnectWallet'
+import { SafeAppAlert } from '@/lib/shared/components/alerts/SafeAppAlert'
 
 export function SwapForm() {
   const {
@@ -130,6 +131,7 @@ export function SwapForm() {
           </CardHeader>
           <CardBody as={VStack} align="start">
             <VStack spacing="md" w="full">
+              <SafeAppAlert />
               <ChainSelect
                 value={selectedChain}
                 onChange={newValue => {

--- a/lib/modules/web3/useWalletConnectMetadata.tsx
+++ b/lib/modules/web3/useWalletConnectMetadata.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { useUserAccount } from './UserAccountProvider'
+
+export function useWalletConnectMetadata() {
+  const [walletName, setWalletName] = useState('')
+  const { connector } = useUserAccount()
+
+  useEffect(() => {
+    if (!connector?.getProvider) return
+    if (connector.id !== 'walletConnect') return
+    connector.getProvider().then(provider => {
+      const walletConnectProvider = provider as any
+      try {
+        setWalletName(walletConnectProvider.session.peer.metadata.name)
+      } catch {
+        // Ignore errors in metadata
+      }
+    })
+  }, [connector])
+
+  const isSafeAccountViaWalletConnect = walletName === 'Safe{Wallet}'
+
+  return { isSafeAccountViaWalletConnect }
+}

--- a/lib/shared/components/alerts/BalAlertContent.tsx
+++ b/lib/shared/components/alerts/BalAlertContent.tsx
@@ -8,6 +8,7 @@ type AlertContentProps = {
   title?: string
   description?: ReactNode | string
   tooltipLabel?: string
+  forceColumnMode?: boolean
 }
 
 // Utility component to display a title, description, optional tooltip and other nested components (buttons, links...) within an alert
@@ -15,12 +16,17 @@ export function BalAlertContent({
   title,
   description,
   tooltipLabel,
+  // Set to true to always display the title and description in a column layout
+  forceColumnMode = false,
   children,
 }: PropsWithChildren<AlertContentProps>) {
   return (
     <HStack w="full" flexWrap="wrap" justifyContent="space-between">
       <HStack maxWidth={{ base: '100%', md: '80%' }} flexWrap="wrap">
-        <Flex direction={{ base: 'column', md: 'row' }} gap={{ base: '0', md: 'sm' }}>
+        <Flex
+          direction={forceColumnMode ? 'column' : { base: 'column', md: 'row' }}
+          gap={forceColumnMode ? '0' : { base: '0', md: 'sm' }}
+        >
           <HStack gap="xs">
             {title && (
               <Text fontWeight="bold" color="black" minWidth="max-content">

--- a/lib/shared/components/alerts/SafeAppAlert.tsx
+++ b/lib/shared/components/alerts/SafeAppAlert.tsx
@@ -9,12 +9,12 @@ export function SafeAppAlert() {
   const { isMobile } = useBreakpoints()
   const { isSafeAccountViaWalletConnect } = useWalletConnectMetadata()
   if (isSafeAccountViaWalletConnect && !isMobile) {
-    return <BalAlert content={<Title />} status="info" />
+    return <BalAlert content={<Content />} status="info" />
   }
   return null
 }
 
-function Title() {
+function Content() {
   return (
     <HStack flexWrap={{ base: 'wrap', md: 'nowrap' }}>
       <BalAlertContent

--- a/lib/shared/components/alerts/SafeAppAlert.tsx
+++ b/lib/shared/components/alerts/SafeAppAlert.tsx
@@ -3,10 +3,14 @@ import { BalAlert } from './BalAlert'
 import { BalAlertButtonLink } from './BalAlertButtonLink'
 import { BalAlertContent } from './BalAlertContent'
 import { useWalletConnectMetadata } from '@/lib/modules/web3/useWalletConnectMetadata'
+import { useBreakpoints } from '../../hooks/useBreakpoints'
 
 export function SafeAppAlert() {
+  const { isMobile } = useBreakpoints()
   const { isSafeAccountViaWalletConnect } = useWalletConnectMetadata()
-  if (isSafeAccountViaWalletConnect) return <BalAlert content={<Title />} status="info" />
+  if (isSafeAccountViaWalletConnect && !isMobile) {
+    return <BalAlert content={<Title />} status="info" />
+  }
   return null
 }
 

--- a/lib/shared/components/alerts/SafeAppAlert.tsx
+++ b/lib/shared/components/alerts/SafeAppAlert.tsx
@@ -1,0 +1,26 @@
+import { HStack } from '@chakra-ui/react'
+import { BalAlert } from './BalAlert'
+import { BalAlertButtonLink } from './BalAlertButtonLink'
+import { BalAlertContent } from './BalAlertContent'
+import { useWalletConnectMetadata } from '@/lib/modules/web3/useWalletConnectMetadata'
+
+export function SafeAppAlert() {
+  const { isSafeAccountViaWalletConnect } = useWalletConnectMetadata()
+  if (isSafeAccountViaWalletConnect) return <BalAlert content={<Title />} status="info" />
+  return null
+}
+
+function Title() {
+  return (
+    <HStack flexWrap={{ base: 'wrap', md: 'nowrap' }}>
+      <BalAlertContent
+        title="Consider using the Balancer Safe web app"
+        description="For a better experience, use the Balancer Safe app with your Safe wallet."
+        forceColumnMode
+      ></BalAlertContent>
+      <BalAlertButtonLink href="https://app.safe.global/share/safe-app?appUrl=https://balancer.fi/pools">
+        Open app
+      </BalAlertButtonLink>
+    </HStack>
+  )
+}


### PR DESCRIPTION
Detects when a user is connected to a Safe Account via Wallet Connect and shows an alert in the main flows. 

It does not show the alert when `isMobile` is true.

Examples:

<img width="632" alt="swap" src="https://github.com/user-attachments/assets/067b6f31-2c56-4ea3-bc77-fc66d69ddf30">

<img width="653" alt="add" src="https://github.com/user-attachments/assets/6d2805f4-a482-4e25-97de-8e78b85da150">

It does not show the alerts when the user is connected to a Safe Account within the Safe App.



