### PR TITLE
fix: preserve Safe App connection after new EOA connections

### DIFF
--- a/lib/modules/web3/UserAccountProvider.tsx
+++ b/lib/modules/web3/UserAccountProvider.tsx
@@ -11,6 +11,7 @@ import { setTag, setUser } from '@sentry/nextjs'
 import { config, isProd } from '@/lib/config/app.config'
 import { captureError, ensureError } from '@/lib/shared/utils/errors'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
+import { useSafeAppConnectionGuard } from './useSafeAppConnectionGuard'
 
 async function isAuthorizedAddress(address: Address): Promise<boolean> {
   try {
@@ -70,6 +71,8 @@ export function _useUserAccount() {
     connector: isMounted ? query.connector : undefined,
     isBlocked,
   }
+
+  useSafeAppConnectionGuard(result.connector, result.chainId)
 
   useEffect(() => {
     if (result.userAddress) {

--- a/lib/modules/web3/useSafeAppConnectionGuard.tsx
+++ b/lib/modules/web3/useSafeAppConnectionGuard.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { Connector, useConnect } from 'wagmi'
+import { useEffect } from 'react'
+
+/*
+  If the app is running as a Safe App and an EOA connection is created in another tab,
+  this hook will ensure that the Safe App tab keeps connected to the Safe account.
+*/
+export function useSafeAppConnectionGuard(newConnector?: Connector, chainId?: number) {
+  const { connect, connectors } = useConnect()
+  useEffect(() => {
+    const safeConnector = connectors.find(c => c.id === 'safe')
+    if (newConnector && newConnector?.id !== 'safe' && safeConnector) {
+      connect({ chainId, connector: safeConnector })
+    }
+  }, [newConnector])
+}


### PR DESCRIPTION
**Before**: 
The app is running as a Safe App and a new EOA connection in another tab also changes the active connection in the Safe App tab.

https://github.com/user-attachments/assets/10eb0eb6-c26b-4c3f-80bd-8ee915f39f38

**After**: 
The Safe account is preserved in the Safe App tab.

https://github.com/user-attachments/assets/897d3acd-2e82-4c5d-93d3-2b2c687be860






