### PR TITLE
fix: improve wallet check reponse error detection

### DIFF
--- a/app/api/wallet-check/[address]/route.ts
+++ b/app/api/wallet-check/[address]/route.ts
@@ -62,11 +62,13 @@ export async function GET(request: Request, { params: { address } }: Params) {
       },
     })
 
-    const {
-      data: [check],
-    }: ReputationResponse = await res.json()
+    const response: ReputationResponse = await res.json()
+    const recommendation = response.data[0]?.recommendation
+    if (!recommendation) {
+      throw new Error('Invalid reputation response: ' + JSON.stringify(response.data))
+    }
 
-    const isAuthorized = check.recommendation !== 'Deny'
+    const isAuthorized = recommendation !== 'Deny'
 
     return NextResponse.json({ isAuthorized })
   } catch (err) {


### PR DESCRIPTION
We are capturing [many wallet-check issues](https://balancer-labs.sentry.io/issues/5696445439/events/e2fa7b21bcf14e4b829b911fec10a719/?project=4506382607712256&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=previous-event&sort=freq&statsPeriod=7d&stream_index=0) with this error: 
`Cannot destructure property 'Symbol(Symbol.iterator)' of '(intermediate value)' as it is null.`
so it's not clear what it is happening. 

Manually testing some of the addresses in those issues worked ok. 

This code tries to log the wrong responses  to better understand the issue.