### PR TITLE
fix: detect response status errors in reputation request

### DIFF
--- a/app/api/wallet-check/[address]/route.ts
+++ b/app/api/wallet-check/[address]/route.ts
@@ -62,6 +62,10 @@ export async function GET(request: Request, { params: { address } }: Params) {
       },
     })
 
+    if (!res.ok) {
+      throw new Error('Failed to fetch reputation. Response status: ' + res.status)
+    }
+
     const response: ReputationResponse = await res.json()
     const recommendation = response.data[0]?.recommendation
     if (!recommendation) {


### PR DESCRIPTION
This should confirm if we are getting 401's as you suspected @garethfuller 