### PR TITLE
fix: add isSafeApp check to Safe App guard

### DIFF
--- a/lib/modules/web3/UserAccountProvider.tsx
+++ b/lib/modules/web3/UserAccountProvider.tsx
@@ -11,7 +11,7 @@ import { setTag, setUser } from '@sentry/nextjs'
 import { config, isProd } from '@/lib/config/app.config'
 import { captureError, ensureError } from '@/lib/shared/utils/errors'
 import { useIsMounted } from '@/lib/shared/hooks/useIsMounted'
-// import { useSafeAppConnectionGuard } from './useSafeAppConnectionGuard'
+import { useSafeAppConnectionGuard } from './useSafeAppConnectionGuard'
 
 async function isAuthorizedAddress(address: Address): Promise<boolean> {
   try {
@@ -72,7 +72,7 @@ export function _useUserAccount() {
     isBlocked,
   }
 
-  // useSafeAppConnectionGuard(result.connector, result.chainId)
+  useSafeAppConnectionGuard(result.connector, result.chainId)
 
   useEffect(() => {
     if (result.userAddress) {

--- a/lib/modules/web3/useSafeAppConnectionGuard.tsx
+++ b/lib/modules/web3/useSafeAppConnectionGuard.tsx
@@ -10,8 +10,20 @@ export function useSafeAppConnectionGuard(newConnector?: Connector, chainId?: nu
   const { connect, connectors } = useConnect()
   useEffect(() => {
     const safeConnector = connectors.find(c => c.id === 'safe')
-    if (newConnector && newConnector?.id !== 'safe' && safeConnector) {
+    if (isSafeApp() && newConnector && newConnector?.id !== 'safe' && safeConnector) {
       connect({ chainId, connector: safeConnector })
     }
   }, [newConnector])
+}
+
+/*
+  There are some edge-cases where the `window.location.ancestorOrigins` is not available.
+  We ignore the errors so the guard will not work in those edge-cases.
+ */
+function isSafeApp() {
+  try {
+    return window.location.ancestorOrigins[0] === 'https://app.safe.global'
+  } catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
The `useSafeAppConnectionGuard` was causing issues when connecting outside Safe App (for example with rabby).
This fix adds a new check to make sure that the guard is only executed when running inside `https://app.safe.global`.
