### PR TITLE
feat: Add point multiples to categories

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
+++ b/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
@@ -5,7 +5,7 @@ import PoolMetaBadges from './PoolMetaBadges'
 import { usePool } from '../../PoolProvider'
 import { shouldBlockAddLiquidity } from '../../pool.helpers'
 import { AnalyticsEvent, trackEvent } from '@/lib/shared/services/fathom/Fathom'
-import { PoolCategories } from '../../categories/PoolCategores'
+import { PoolCategories } from '../../categories/PoolCategories'
 import { PoolBreadcrumbs } from './PoolBreadcrumbs'
 
 export function PoolHeader() {

--- a/lib/modules/pool/categories/PoolCategories.tsx
+++ b/lib/modules/pool/categories/PoolCategories.tsx
@@ -17,10 +17,20 @@ import { PoolCategory } from './getPoolCategories'
 import { usePool } from '../PoolProvider'
 import { usePoolCategories } from './PoolCategoriesProvider'
 import NextLink from 'next/link'
+import { isInteger, toNumber } from 'lodash'
 
 function PoolCategoryBadge({ category }: { category: PoolCategory }) {
   const { getCategoryIconSrc } = usePoolCategories()
   const categoryIconSrc = getCategoryIconSrc(category)
+
+  function CategoryValue() {
+    if (category.value) {
+      if (category.id.includes('points') && isInteger(toNumber(category.value))) {
+        return <Text ml="xs" mr="xs">{`${category.value}x`}</Text>
+      }
+    }
+    return null
+  }
 
   return (
     <Popover trigger="hover">
@@ -63,6 +73,7 @@ function PoolCategoryBadge({ category }: { category: PoolCategory }) {
                 {category.name}
               </Text>
             )}
+            <CategoryValue />
           </Badge>
         </HStack>
       </PopoverTrigger>

--- a/lib/modules/pool/categories/getPoolCategories.ts
+++ b/lib/modules/pool/categories/getPoolCategories.ts
@@ -10,6 +10,7 @@ export type PoolCategory = {
   id: string
   name: string
   description: string
+  value?: string
   url?: string
   fileIcon?: string
   iconUrl?: string


### PR DESCRIPTION
Adds multiple text to category badge if the category metadata has a 'value' attribute and 'points' in it's id.

<img width="488" alt="Screenshot 2024-08-28 at 16 13 39" src="https://github.com/user-attachments/assets/c17dfcc6-93e7-49fc-9a85-77222cbe7361">
