### PR TITLE
fix: Remove duplicate pool event queries

### DIFF
--- a/lib/modules/pool/PoolDetail/PoolDetail.tsx
+++ b/lib/modules/pool/PoolDetail/PoolDetail.tsx
@@ -29,13 +29,19 @@ export function PoolDetail() {
   const { userAddress, isConnected } = useUserAccount()
   const {
     data: userPoolEventsData,
+    loading: isLoadingUserPoolEvents,
     startPolling,
     stopPolling,
-  } = usePoolEvents({
-    chainIn: [chain],
-    poolIdIn: [pool.id],
-    userAddress,
-  })
+  } = usePoolEvents(
+    {
+      chainIn: [chain],
+      poolIdIn: [pool.id],
+      userAddress,
+    },
+    {
+      skip: !isConnected,
+    }
+  )
 
   useEffect(() => {
     startPolling(120000)
@@ -43,11 +49,13 @@ export function PoolDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const userPoolEvents = userPoolEventsData?.poolEvents
+
   const userhasPoolEvents = useMemo(() => {
-    if (userPoolEventsData) {
-      return userPoolEventsData.poolEvents?.length > 0
+    if (userPoolEvents) {
+      return userPoolEvents?.length > 0
     }
-  }, [userPoolEventsData])
+  }, [userPoolEvents])
 
   const userHasLiquidity = hasTotalBalance(pool)
 
@@ -82,7 +90,10 @@ export function PoolDetail() {
                 justifyContent="stretch"
               >
                 <PoolMyLiquidity />
-                <PoolUserEvents />
+                <PoolUserEvents
+                  userPoolEvents={userPoolEvents}
+                  isLoading={isLoadingUserPoolEvents}
+                />
               </Stack>
             )}
             <PoolActivity />

--- a/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
+++ b/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
@@ -14,17 +14,16 @@ import {
 import { usePool } from '../PoolProvider'
 import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useCurrency } from '@/lib/shared/hooks/useCurrency'
-import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
+import { GetPoolEventsQuery, GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { TokenIcon } from '@/lib/modules/tokens/TokenIcon'
 import { formatDistanceToNow, secondsToMilliseconds } from 'date-fns'
 import { useBlockExplorer } from '@/lib/shared/hooks/useBlockExplorer'
 import { ArrowUpRight } from 'react-feather'
-import { PoolEventItem, usePoolEvents } from '../usePoolEvents'
+import { PoolEventItem } from '../usePoolEvents'
 import { calcTotalStakedBalance, getUserTotalBalance } from '../user-balance.helpers'
 import { fNum, bn } from '@/lib/shared/utils/numbers'
 import { useVebalBoost } from '@/lib/modules/vebal/useVebalBoost'
 import { isEmpty } from 'lodash'
-import { useUserAccount } from '../../web3/UserAccountProvider'
 import { isVebalPool } from '../pool.helpers'
 
 type PoolEventRowProps = {
@@ -106,19 +105,19 @@ function PoolEventRow({ poolEvent, usdValue, chain, txUrl }: PoolEventRowProps) 
   )
 }
 
-export default function PoolUserEvents() {
+export default function PoolUserEvents({
+  userPoolEvents,
+  isLoading,
+}: {
+  userPoolEvents: GetPoolEventsQuery['poolEvents'] | undefined
+  isLoading: boolean
+}) {
   const { myLiquiditySectionRef, chain, pool } = usePool()
   const [height, setHeight] = useState(0)
   const [poolEvents, setPoolEvents] = useState<PoolEventItem[]>([])
   const { toCurrency } = useCurrency()
   const { getBlockExplorerTxUrl } = useBlockExplorer(chain)
   const { veBalBoostMap } = useVebalBoost([pool])
-  const { userAddress } = useUserAccount()
-  const { data: userPoolEventsData, loading: isLoading } = usePoolEvents({
-    chainIn: [chain],
-    poolIdIn: [pool.id],
-    userAddress,
-  })
 
   const isVeBal = isVebalPool(pool.id)
   const showBoostValue = !isVeBal
@@ -132,10 +131,10 @@ export default function PoolUserEvents() {
   }, [])
 
   useEffect(() => {
-    if (!isLoading && userPoolEventsData?.poolEvents.length) {
-      setPoolEvents(userPoolEventsData.poolEvents)
+    if (!isLoading && userPoolEvents?.length) {
+      setPoolEvents(userPoolEvents)
     }
-  }, [userPoolEventsData, isLoading])
+  }, [userPoolEvents, isLoading])
 
   function getShareTitle() {
     if (isVeBal) {

--- a/lib/modules/pool/usePoolEvents.tsx
+++ b/lib/modules/pool/usePoolEvents.tsx
@@ -5,6 +5,7 @@ import {
   GqlPoolEventsDataRange,
   GetPoolEventsQuery,
 } from '@/lib/shared/services/api/generated/graphql'
+import { FetchPolicy } from '@apollo/client'
 import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr'
 
 type PoolEventList = GetPoolEventsQuery['poolEvents']
@@ -20,15 +21,10 @@ type PoolEventsProps = {
   userAddress?: string
 }
 
-export function usePoolEvents({
-  poolIdIn,
-  chainIn,
-  first,
-  skip,
-  range,
-  typeIn,
-  userAddress,
-}: PoolEventsProps) {
+export function usePoolEvents(
+  { poolIdIn, chainIn, first, skip, range, typeIn, userAddress }: PoolEventsProps,
+  opts: { skip?: boolean; fetchPolicy?: FetchPolicy } = {}
+) {
   const poolIds = (poolIdIn || []).map(id => id.toLowerCase())
 
   return useQuery(GetPoolEventsDocument, {
@@ -41,5 +37,6 @@ export function usePoolEvents({
       typeIn,
       userAddress,
     },
+    ...opts,
   })
 }


### PR DESCRIPTION
We had a duplicate `GetPoolEventsDocument` query in a nested component. This fix removes the duplicate query and passes the data down through a prop. It also adds the `skip` option to prevent the query running if the user is not connected.