### PR TITLE
fix: page jump on load

### DIFF
--- a/lib/shared/components/tables/PaginatedTable.tsx
+++ b/lib/shared/components/tables/PaginatedTable.tsx
@@ -64,7 +64,7 @@ export function PaginatedTable({
             </Center>
           )}
           {loading && (
-            <Box py="2xl">
+            <Box>
               <Box
                 style={{
                   position: 'absolute',


### PR DESCRIPTION
Fix jumping of the page while the table is fetching new rows.

Before: https://balancerecosystem.slack.com/archives/C05H1NS8Q8L/p1725034983703829

After:
![jump](https://github.com/user-attachments/assets/5aaf4e38-2bae-41f1-9f13-432a6d48d487)
