### PR TITLE
fix: use staletime instead of gcTime to avoid extra balance rpc requests

### DIFF
--- a/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -43,7 +43,7 @@ export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[
     address: userAddress,
     query: {
       enabled: !!userAddress && includesNativeAsset,
-      gcTime: BALANCE_CACHE_TIME_MS,
+      staleTime: BALANCE_CACHE_TIME_MS,
     },
   })
 

--- a/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -43,6 +43,10 @@ export function _useTokenBalances(initTokens?: GqlToken[], extTokens?: GqlToken[
     address: userAddress,
     query: {
       enabled: !!userAddress && includesNativeAsset,
+      /*
+        Cache without requests in the background
+        More info: https://tkdodo.eu/blog/practical-react-query#the-defaults-explained
+      */
       staleTime: BALANCE_CACHE_TIME_MS,
     },
   })


### PR DESCRIPTION
In the swap page, we had a react query "cache" of 30 seconds to reuse cached balances in case the user is switching back and forth between the same chains in the chain selector.

But should use staleTime instead of gcTime so that the balances are not requested again.

This should save some requests and avoid some 429's in edge-cases. 

From https://tkdodo.eu/blog/practical-react-query#the-defaults-explained

> Secondly, there seems to be a bit of confusion between gcTime and staleTime, so let me try to clear that up:
> 
> staleTime: The duration until a query transitions from fresh to stale. As long as the query is fresh, data will always be read from the cache only - no network request will happen! If the query is stale (which per default is: instantly), you will still get data from the cache, but a background refetch can happen [under certain conditions](https://tanstack.com/query/latest/docs/react/guides/caching).
> gcTime: The duration until inactive queries will be removed from the cache. This defaults to 5 minutes. Queries transition to the inactive state as soon as there are no observers registered, so when all components which use that query have unmounted.