### PR TITLE
fix: sentry stack trace detection

### DIFF
--- a/app/react-query.provider.tsx
+++ b/app/react-query.provider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { captureError } from '@/lib/shared/utils/errors'
-import { SentryMetadata, captureSentryError } from '@/lib/shared/utils/query-errors'
+import { SentryMetadata, captureSentryError, shouldIgnore } from '@/lib/shared/utils/query-errors'
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 
@@ -9,6 +9,7 @@ export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     // Global handler for every react-query error
     onError: (error, query) => {
+      if (shouldIgnore(error.message, error.stack)) return
       console.log('Sentry capturing error: ', {
         meta: query?.meta,
         error,

--- a/app/react-query.provider.tsx
+++ b/app/react-query.provider.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import { captureError } from '@/lib/shared/utils/errors'
-import {
-  SentryMetadata,
-  captureSentryError,
-  shouldIgnoreError,
-} from '@/lib/shared/utils/query-errors'
+import { SentryMetadata, captureSentryError } from '@/lib/shared/utils/query-errors'
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 
@@ -13,7 +9,6 @@ export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     // Global handler for every react-query error
     onError: (error, query) => {
-      if (shouldIgnoreError(error)) return
       console.log('Sentry capturing error: ', {
         meta: query?.meta,
         error,

--- a/lib/shared/utils/query-errors.spec.ts
+++ b/lib/shared/utils/query-errors.spec.ts
@@ -4,8 +4,9 @@ import {
   sentryMetaForRemoveLiquidityHandler,
   captureSentryError,
   sentryMetaForWagmiSimulation,
-  shouldIgnoreError,
+  shouldIgnoreException,
 } from '@/lib/shared/utils/query-errors'
+import { Exception as SentryException } from '@sentry/nextjs'
 import { defaultTestUserAccount } from '@/test/anvil/anvil-setup'
 import * as Sentry from '@sentry/nextjs'
 import { waitFor } from '@testing-library/react'
@@ -147,20 +148,17 @@ describe('Captures sentry error', () => {
 
 describe('shouldIgnoreError', () => {
   it('Ignores errors', () => {
-    expect(shouldIgnoreError(new Error('e.getAccounts is not a function'))).toBeTruthy()
-    expect(shouldIgnoreError(new Error('foo bar baz'))).toBeFalsy()
-    expect(shouldIgnoreError(new Error('foo bar baz'))).toBeFalsy()
+    expect(
+      shouldIgnoreException(createSentryException('e.getAccounts is not a function'))
+    ).toBeTruthy()
+    expect(shouldIgnoreException(createSentryException('foo bar baz'))).toBeFalsy()
   })
+
   it('when error does not have message', () => {
-    class TestError extends Error {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      constructor(message: string) {
-        super(undefined)
-        this.name = 'TestError'
-        // @ts-expect-error we want to test when error does not have message
-        this.message = undefined
-      }
-    }
-    expect(shouldIgnoreError(new TestError('e.getAccounts is not a function'))).toBeFalsy()
+    expect(shouldIgnoreException(createSentryException(''))).toBeFalsy()
   })
 })
+
+function createSentryException(errorMessage: string) {
+  return { value: errorMessage } as SentryException
+}

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -238,7 +238,7 @@ export function shouldIgnoreException(sentryException: SentryException) {
   return ignored
 }
 
-export function shouldIgnore(message: string, sentryStack = ''): boolean {
+export function shouldIgnore(message: string, stackTrace = ''): boolean {
   if (isUserRejectedError(new Error(message))) return true
 
   /*
@@ -277,12 +277,8 @@ export function shouldIgnore(message: string, sentryStack = ''): boolean {
   */
   if (
     message.startsWith('Maximum call stack size exceeded') &&
-    sentryStack.includes('injectWalletGuard.js')
+    stackTrace.includes('injectWalletGuard.js')
   ) {
-    return true
-  }
-
-  if (sentryStack.includes('PoolList')) {
     return true
   }
 
@@ -290,7 +286,7 @@ export function shouldIgnore(message: string, sentryStack = ''): boolean {
     com.okex.wallet injects code that causes this error
     Examples: https://balancer-labs.sentry.io/issues/5687846148/
   */
-  if (message.startsWith('Cannot redefine property:') && sentryStack.includes('inject.bundle.js')) {
+  if (message.startsWith('Cannot redefine property:') && stackTrace.includes('inject.bundle.js')) {
     return true
   }
 
@@ -303,7 +299,7 @@ export function shouldIgnore(message: string, sentryStack = ''): boolean {
   */
   if (
     message === "Cannot read properties of undefined (reading 'address')" &&
-    sentryStack.includes('getWalletClient.js')
+    stackTrace.includes('getWalletClient.js')
   ) {
     return true
   }

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -238,7 +238,7 @@ export function shouldIgnoreException(sentryException: SentryException) {
   return ignored
 }
 
-function shouldIgnore(message: string, sentryStack: string): boolean {
+export function shouldIgnore(message: string, sentryStack = ''): boolean {
   if (isUserRejectedError(new Error(message))) return true
 
   /*
@@ -314,8 +314,9 @@ function shouldIgnore(message: string, sentryStack: string): boolean {
   */
   if (
     message.startsWith('Error: WebSocket connection failed for host: wss://relay.walletconnect.com')
-  )
+  ) {
     return true
+  }
 
   return false
 }

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -1,5 +1,10 @@
 import { captureException } from '@sentry/nextjs'
-import { Extras, ScopeContext } from '@sentry/types'
+import {
+  Extras,
+  ScopeContext,
+  Stacktrace as SentryStack,
+  Exception as SentryException,
+} from '@sentry/types'
 import { SentryError, ensureError } from './errors'
 import { isUserRejectedError } from './error-filters'
 import {
@@ -226,55 +231,58 @@ export function captureSentryError(
 /*
   Detects common errors that we don't want to capture in Sentry
 */
-export function shouldIgnoreError(e: Error) {
+export function shouldIgnoreException(sentryException: SentryException) {
+  const errorMessage = sentryException.value || ''
+  const ignored = shouldIgnore(errorMessage, sentryStackFramesToString(sentryException.stacktrace))
+  if (ignored && !isProd) console.log('Ignoring error with message: ', errorMessage)
+  return ignored
+}
+
+function shouldIgnore(message: string, sentryStack: string): boolean {
+  if (isUserRejectedError(new Error(message))) return true
+
   /*
     Thrown from useWalletClient() when loading a pool page from scratch.
     It looks like is is caused by the useWalletClient call in AddTokenToWalletButton but it does not affect it's behavior.
   */
-  const ignored = shouldIgnore(e)
-  if (ignored && !isProd) console.log('Ignoring error with message: ', e.message)
-  return ignored
-}
-
-function shouldIgnore(e: Error): boolean {
-  if (!e?.message) return false
-
-  if (isUserRejectedError(e)) return true
-
-  if (e.message.includes('.getAccounts is not a function')) return true
+  if (message.includes('.getAccounts is not a function')) return true
 
   /*
     Error thrown by Library detector chrome extension:
     https://chromewebstore.google.com/detail/library-detector/cgaocdmhkmfnkdkbnckgmpopcbpaaejo?hl=en
   */
-  if (e.message.includes(`Cannot set properties of null (setting 'content')`)) return true
+  if (message.includes(`Cannot set properties of null (setting 'content')`)) return true
 
   /*
     Frequent errors in rainbowkit + wagmi that do not mean a real crash
   */
-  if (e.message.includes('Connector not connected')) return true
-  if (e.message.includes('Provider not found')) return true
+  if (message.includes('Connector not connected')) return true
+  if (message.includes('Provider not found')) return true
 
   /*
     More info: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
   */
-  if (e.message.includes('ResizeObserver loop limit exceeded')) return true
+  if (message.includes('ResizeObserver loop limit exceeded')) return true
 
   /*
     Wallet Connect bug when switching certain networks.
     It does not crash the app.
     More info: https://github.com/MetaMask/metamask-mobile/issues/9157
   */
-  if (e.message.includes('Missing or invalid. emit() chainId')) return true
+  if (message.includes('Missing or invalid. emit() chainId')) return true
 
   /*
     Some extensions cause this error
     Examples: https://balancer-labs.sentry.io/issues/5623611453/
   */
   if (
-    e.message.startsWith('Maximum call stack size exceeded') &&
-    e.stack?.includes('injectWalletGuard.js')
+    message.startsWith('Maximum call stack size exceeded') &&
+    sentryStack.includes('injectWalletGuard.js')
   ) {
+    return true
+  }
+
+  if (sentryStack.includes('PoolList')) {
     return true
   }
 
@@ -282,7 +290,7 @@ function shouldIgnore(e: Error): boolean {
     com.okex.wallet injects code that causes this error
     Examples: https://balancer-labs.sentry.io/issues/5687846148/
   */
-  if (e.message.startsWith('Cannot redefine property:') && e.stack?.includes('inject.bundle.js')) {
+  if (message.startsWith('Cannot redefine property:') && sentryStack.includes('inject.bundle.js')) {
     return true
   }
 
@@ -294,8 +302,8 @@ function shouldIgnore(e: Error): boolean {
       3. Click "Connect wallet" and chose WalletConnect
   */
   if (
-    e.message === "Cannot read properties of undefined (reading 'address')" &&
-    e.stack?.includes('getWalletClient.js')
+    message === "Cannot read properties of undefined (reading 'address')" &&
+    sentryStack.includes('getWalletClient.js')
   ) {
     return true
   }
@@ -305,11 +313,20 @@ function shouldIgnore(e: Error): boolean {
     More info: https://github.com/WalletConnect/walletconnect-monorepo/issues/4318
   */
   if (
-    e.message.startsWith(
-      'Error: WebSocket connection failed for host: wss://relay.walletconnect.com'
-    )
+    message.startsWith('Error: WebSocket connection failed for host: wss://relay.walletconnect.com')
   )
     return true
 
   return false
+}
+
+function sentryStackFramesToString(sentryStack?: SentryStack): string {
+  if (!sentryStack?.frames?.length) return ''
+  return (
+    sentryStack.frames
+      // We only check the last 4 frames (root of the error)
+      .slice(-4)
+      .map(frame => frame.filename || '')
+      .join()
+  )
 }

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { sentryDSN } from './sentry.config'
 import { isProd } from './lib/config/app.config'
-import { shouldIgnoreError } from './lib/shared/utils/query-errors'
+import { shouldIgnoreException } from './lib/shared/utils/query-errors'
 
 Sentry.init({
   // Change this value only if you need to debug in development (we have a custom developmentSentryDSN for that)
@@ -84,7 +84,7 @@ Sentry.init({
 
 function handleNonFatalError(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
   const firstValue = getFirstExceptionValue(event)
-  if (firstValue && shouldIgnoreError(new Error(firstValue.value))) return null
+  if (firstValue && shouldIgnoreException(firstValue)) return null
   return event
 }
 
@@ -97,7 +97,7 @@ function handleFatalError(
   if (event?.exception?.values?.length) {
     const firstValue = event.exception.values[0]
 
-    if (shouldIgnoreError(new Error(firstValue.value))) return null
+    if (shouldIgnoreException(firstValue)) return null
 
     const flowType = uppercaseSegment(criticalFlowPath)
     firstValue.value = `Unexpected error in ${flowType} flow.

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -85,6 +85,7 @@ Sentry.init({
 function handleNonFatalError(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
   const firstValue = getFirstExceptionValue(event)
   if (firstValue && shouldIgnoreException(firstValue)) return null
+  event.level = 'error'
   return event
 }
 


### PR DESCRIPTION
Sentry stack traces are not like native JS ones so we need to convert them into string to be able to use `.includes`