### PR TITLE
fix: Explicitly set swap handler name

### DIFF
--- a/lib/modules/swap/handlers/AuraBalSwap.handler.ts
+++ b/lib/modules/swap/handlers/AuraBalSwap.handler.ts
@@ -14,6 +14,8 @@ import { isNativeAsset, isSameAddress } from '@/lib/shared/utils/addresses'
 import { bn } from '@/lib/shared/utils/numbers'
 
 export class AuraBalSwapHandler implements SwapHandler {
+  name = 'AuraBalSwapHandler'
+
   constructor(public tokens: GqlToken[]) {}
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<AuraBalSimulateSwapResponse> {

--- a/lib/modules/swap/handlers/DefaultSwap.handler.ts
+++ b/lib/modules/swap/handlers/DefaultSwap.handler.ts
@@ -9,6 +9,8 @@ import { SdkBuildSwapInputs, SdkSimulateSwapResponse, SimulateSwapInputs } from 
 import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 
 export class DefaultSwapHandler implements SwapHandler {
+  name = 'DefaultSwapHandler'
+
   constructor(public apolloClient: ApolloClient<object>) {}
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SdkSimulateSwapResponse> {

--- a/lib/modules/swap/handlers/LidoWrap.handler.ts
+++ b/lib/modules/swap/handlers/LidoWrap.handler.ts
@@ -20,6 +20,8 @@ const lidoRateProviderMap: Partial<Record<GqlChain, Address>> = {
 }
 
 export class LidoWrapHandler implements SwapHandler {
+  name = 'LidoWrapHandler'
+
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SimulateSwapResponse> {
     const wrapType = getWrapType(variables.tokenIn, variables.tokenOut, variables.chain)
     if (!wrapType) throw new Error('LidoWrapHandler called with non valid wrap tokens')

--- a/lib/modules/swap/handlers/NativeWrap.handler.ts
+++ b/lib/modules/swap/handlers/NativeWrap.handler.ts
@@ -13,6 +13,8 @@ import { encodeFunctionData } from 'viem'
 import { Hex } from 'viem'
 
 export class NativeWrapHandler implements SwapHandler {
+  name = 'NativeWrapHandler'
+
   constructor(public apolloClient: ApolloClient<object>) {}
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SimulateSwapResponse> {

--- a/lib/modules/swap/handlers/Swap.handler.ts
+++ b/lib/modules/swap/handlers/Swap.handler.ts
@@ -10,6 +10,7 @@ import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
 export interface SwapHandler {
   apolloClient?: ApolloClient<object>
   tokens?: GqlToken[]
+  name: string
 
   simulate(inputs: SimulateSwapInputs): Promise<SimulateSwapResponse>
   build(inputs: BuildSwapInputs): TransactionConfig

--- a/lib/modules/swap/useSwapSteps.tsx
+++ b/lib/modules/swap/useSwapSteps.tsx
@@ -33,7 +33,7 @@ export function useSwapSteps({
     useApproveRelayerStep(chainId)
   const signRelayerStep = useSignRelayerStep(swapState.selectedChain)
 
-  const swapRequiresRelayer = handler.constructor.name === 'AuraBalSwapHandler'
+  const swapRequiresRelayer = handler.name === 'AuraBalSwapHandler'
 
   const humanAmountIn = swapState.tokenIn.amount
   const tokenInAmounts = useMemo(() => {


### PR DESCRIPTION
In production builds the Class.contstructor.name changes, so this was breaking the production conditional.