### PR TITLE
fix: use rpc url from transports in handlers

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/handlers/NestedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/NestedAddLiquidity.handler.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   AddLiquidityNested,
@@ -13,6 +11,7 @@ import { LiquidityActionHelpers, areEmptyAmounts } from '../../LiquidityActionHe
 import { NestedBuildAddLiquidityInput, NestedQueryAddLiquidityOutput } from '../add-liquidity.types'
 import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 /**
  * NestedAddLiquidityHandler is a handler that implements the
@@ -88,7 +87,7 @@ export class NestedAddLiquidityHandler implements AddLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId as ChainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       amountsIn: nonEmptyAmountsIn,
     }
   }

--- a/lib/modules/pool/actions/add-liquidity/handlers/NestedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/NestedAddLiquidity.handler.ts
@@ -11,7 +11,7 @@ import { LiquidityActionHelpers, areEmptyAmounts } from '../../LiquidityActionHe
 import { NestedBuildAddLiquidityInput, NestedQueryAddLiquidityOutput } from '../add-liquidity.types'
 import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 /**
  * NestedAddLiquidityHandler is a handler that implements the
@@ -87,7 +87,7 @@ export class NestedAddLiquidityHandler implements AddLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId as ChainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       amountsIn: nonEmptyAmountsIn,
     }
   }

--- a/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
@@ -12,7 +12,7 @@ import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import { SdkBuildAddLiquidityInput, SdkQueryAddLiquidityOutput } from '../add-liquidity.types'
 import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 /**
  * ProportionalAddLiquidityHandler is a handler that implements the
@@ -79,7 +79,7 @@ export class ProportionalAddLiquidityHandler implements AddLiquidityHandler {
   private constructSdkInput(referenceAmount: InputAmount): AddLiquidityProportionalInput {
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       referenceAmount,
       kind: AddLiquidityKind.Proportional,
     }

--- a/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/ProportionalAddLiquidity.handler.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   AddLiquidity,
@@ -14,6 +12,7 @@ import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import { SdkBuildAddLiquidityInput, SdkQueryAddLiquidityOutput } from '../add-liquidity.types'
 import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 /**
  * ProportionalAddLiquidityHandler is a handler that implements the
@@ -80,7 +79,7 @@ export class ProportionalAddLiquidityHandler implements AddLiquidityHandler {
   private constructSdkInput(referenceAmount: InputAmount): AddLiquidityProportionalInput {
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       referenceAmount,
       kind: AddLiquidityKind.Proportional,
     }

--- a/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
+import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 import {
   AddLiquidity,
   AddLiquidityKind,
@@ -11,9 +12,8 @@ import {
 } from '@balancer/sdk'
 import { Pool } from '../../../PoolProvider'
 import { LiquidityActionHelpers, areEmptyAmounts } from '../../LiquidityActionHelpers'
-import { AddLiquidityHandler } from './AddLiquidity.handler'
 import { SdkBuildAddLiquidityInput, SdkQueryAddLiquidityOutput } from '../add-liquidity.types'
-import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
+import { AddLiquidityHandler } from './AddLiquidity.handler'
 
 /**
  * UnbalancedAddLiquidityHandler is a handler that implements the
@@ -91,7 +91,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       amountsIn,
       kind: AddLiquidityKind.Unbalanced,
     }

--- a/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
+++ b/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidity.handler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 import {
   AddLiquidity,
   AddLiquidityKind,
@@ -91,7 +91,7 @@ export class UnbalancedAddLiquidityHandler implements AddLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       amountsIn,
       kind: AddLiquidityKind.Unbalanced,
     }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
@@ -15,7 +15,7 @@ import {
   QueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 export interface NestedProportionalQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -88,7 +88,7 @@ export class NestedProportionalRemoveLiquidityHandler implements RemoveLiquidity
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
     }
 
     return result

--- a/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
@@ -1,4 +1,3 @@
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   HumanAmount,
@@ -16,6 +15,7 @@ import {
   QueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 export interface NestedProportionalQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -88,7 +88,7 @@ export class NestedProportionalRemoveLiquidityHandler implements RemoveLiquidity
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
     }
 
     return result

--- a/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidity.handler.ts
@@ -1,4 +1,3 @@
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   HumanAmount,
@@ -18,6 +17,7 @@ import {
   QueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 export interface NestedSingleTokenQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -104,7 +104,7 @@ export class NestedSingleTokenRemoveLiquidityHandler implements RemoveLiquidityH
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
     }
 
     return result

--- a/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidity.handler.ts
@@ -17,7 +17,7 @@ import {
   QueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 export interface NestedSingleTokenQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -104,7 +104,7 @@ export class NestedSingleTokenRemoveLiquidityHandler implements RemoveLiquidityH
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
     }
 
     return result

--- a/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
@@ -1,4 +1,3 @@
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   HumanAmount,
@@ -18,6 +17,7 @@ import {
   SdkQueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandler {
   helpers: LiquidityActionHelpers
@@ -79,7 +79,7 @@ export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandle
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       bptIn,
       kind: RemoveLiquidityKind.Proportional,
     }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/ProportionalRemoveLiquidity.handler.ts
@@ -17,7 +17,7 @@ import {
   SdkQueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandler {
   helpers: LiquidityActionHelpers
@@ -79,7 +79,7 @@ export class ProportionalRemoveLiquidityHandler implements RemoveLiquidityHandle
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       bptIn,
       kind: RemoveLiquidityKind.Proportional,
     }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
@@ -13,11 +13,11 @@ import {
   SdkBuildRemoveLiquidityInput,
   SdkQueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import { parseEther } from 'viem'
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 /*
  A recovery exit is just a Proportional one but with Recovery kind
@@ -85,7 +85,7 @@ export class RecoveryRemoveLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       bptIn,
       kind: RemoveLiquidityKind.Recovery,
     }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
@@ -17,7 +17,7 @@ import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import { parseEther } from 'viem'
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 /*
  A recovery exit is just a Proportional one but with Recovery kind
@@ -85,7 +85,7 @@ export class RecoveryRemoveLiquidityHandler {
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       bptIn,
       kind: RemoveLiquidityKind.Recovery,
     }

--- a/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
@@ -20,7 +20,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { SentryError } from '@/lib/shared/utils/errors'
-import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
+import { getRpcUrl } from '@/lib/modules/web3/transports'
 
 export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler {
   helpers: LiquidityActionHelpers
@@ -104,7 +104,7 @@ export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
+      rpcUrl: getRpcUrl(this.helpers.chainId),
       bptIn: bptInInputAmount,
       kind: RemoveLiquidityKind.SingleTokenExactIn,
       tokenOut,

--- a/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
+++ b/lib/modules/pool/actions/remove-liquidity/handlers/SingleTokenRemoveLiquidity.handler.ts
@@ -1,4 +1,3 @@
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
 import { TransactionConfig } from '@/lib/modules/web3/contracts/contract.types'
 import {
   HumanAmount,
@@ -21,6 +20,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { SentryError } from '@/lib/shared/utils/errors'
+import { getHandlerRpcUrl } from '@/lib/modules/web3/transports'
 
 export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler {
   helpers: LiquidityActionHelpers
@@ -104,7 +104,7 @@ export class SingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler
 
     return {
       chainId: this.helpers.chainId,
-      rpcUrl: getDefaultRpcUrl(this.helpers.chainId),
+      rpcUrl: getHandlerRpcUrl(this.helpers.chainId),
       bptIn: bptInInputAmount,
       kind: RemoveLiquidityKind.SingleTokenExactIn,
       tokenOut,

--- a/lib/modules/swap/handlers/AuraBalSwap.handler.ts
+++ b/lib/modules/swap/handlers/AuraBalSwap.handler.ts
@@ -9,7 +9,7 @@ import {
   AuraBalSimulateSwapResponse,
   SimulateSwapInputs,
 } from '../swap.types'
-import { getHandlerRpcUrl } from '../../web3/transports'
+import { getRpcUrl } from '../../web3/transports'
 import { isNativeAsset, isSameAddress } from '@/lib/shared/utils/addresses'
 import { bn } from '@/lib/shared/utils/numbers'
 
@@ -20,7 +20,7 @@ export class AuraBalSwapHandler implements SwapHandler {
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<AuraBalSimulateSwapResponse> {
     const { chain, swapType } = variables
-    const rpcUrl = getHandlerRpcUrl(getChainId(chain))
+    const rpcUrl = getRpcUrl(getChainId(chain))
 
     const tokenInAddress = isNativeAsset(chain, variables.tokenIn)
       ? getWrappedNativeAssetAddress(chain)
@@ -87,7 +87,7 @@ export class AuraBalSwapHandler implements SwapHandler {
     relayerApprovalSignature,
     wethIsEth,
   }: AuraBalBuildSwapInputs): TransactionConfig {
-    const rpcUrl = getHandlerRpcUrl(getChainId(selectedChain))
+    const rpcUrl = getRpcUrl(getChainId(selectedChain))
 
     const auraBalSwap = new AuraBalSwap(rpcUrl)
 

--- a/lib/modules/swap/handlers/AuraBalSwap.handler.ts
+++ b/lib/modules/swap/handlers/AuraBalSwap.handler.ts
@@ -9,7 +9,7 @@ import {
   AuraBalSimulateSwapResponse,
   SimulateSwapInputs,
 } from '../swap.types'
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
+import { getHandlerRpcUrl } from '../../web3/transports'
 import { isNativeAsset, isSameAddress } from '@/lib/shared/utils/addresses'
 import { bn } from '@/lib/shared/utils/numbers'
 
@@ -20,7 +20,7 @@ export class AuraBalSwapHandler implements SwapHandler {
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<AuraBalSimulateSwapResponse> {
     const { chain, swapType } = variables
-    const rpcUrl = getDefaultRpcUrl(getChainId(chain))
+    const rpcUrl = getHandlerRpcUrl(getChainId(chain))
 
     const tokenInAddress = isNativeAsset(chain, variables.tokenIn)
       ? getWrappedNativeAssetAddress(chain)
@@ -87,7 +87,7 @@ export class AuraBalSwapHandler implements SwapHandler {
     relayerApprovalSignature,
     wethIsEth,
   }: AuraBalBuildSwapInputs): TransactionConfig {
-    const rpcUrl = getDefaultRpcUrl(getChainId(selectedChain))
+    const rpcUrl = getHandlerRpcUrl(getChainId(selectedChain))
 
     const auraBalSwap = new AuraBalSwap(rpcUrl)
 

--- a/lib/modules/swap/handlers/DefaultSwap.handler.ts
+++ b/lib/modules/swap/handlers/DefaultSwap.handler.ts
@@ -6,7 +6,7 @@ import { Path, Slippage, Swap, SwapKind, TokenAmount } from '@balancer/sdk'
 import { formatUnits } from 'viem'
 import { TransactionConfig } from '../../web3/contracts/contract.types'
 import { SdkBuildSwapInputs, SdkSimulateSwapResponse, SimulateSwapInputs } from '../swap.types'
-import { getDefaultRpcUrl } from '@/lib/modules/web3/ChainConfig'
+import { getHandlerRpcUrl } from '../../web3/transports'
 
 export class DefaultSwapHandler implements SwapHandler {
   name = 'DefaultSwapHandler'
@@ -15,7 +15,7 @@ export class DefaultSwapHandler implements SwapHandler {
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SdkSimulateSwapResponse> {
     const { chain, swapType } = variables
-    const rpcUrl = getDefaultRpcUrl(getChainId(chain))
+    const rpcUrl = getHandlerRpcUrl(getChainId(chain))
 
     const { data } = await this.apolloClient.query({
       query: GetSorSwapsDocument,

--- a/lib/modules/swap/handlers/DefaultSwap.handler.ts
+++ b/lib/modules/swap/handlers/DefaultSwap.handler.ts
@@ -6,7 +6,7 @@ import { Path, Slippage, Swap, SwapKind, TokenAmount } from '@balancer/sdk'
 import { formatUnits } from 'viem'
 import { TransactionConfig } from '../../web3/contracts/contract.types'
 import { SdkBuildSwapInputs, SdkSimulateSwapResponse, SimulateSwapInputs } from '../swap.types'
-import { getHandlerRpcUrl } from '../../web3/transports'
+import { getRpcUrl } from '../../web3/transports'
 
 export class DefaultSwapHandler implements SwapHandler {
   name = 'DefaultSwapHandler'
@@ -15,7 +15,7 @@ export class DefaultSwapHandler implements SwapHandler {
 
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SdkSimulateSwapResponse> {
     const { chain, swapType } = variables
-    const rpcUrl = getHandlerRpcUrl(getChainId(chain))
+    const rpcUrl = getRpcUrl(getChainId(chain))
 
     const { data } = await this.apolloClient.query({
       query: GetSorSwapsDocument,

--- a/lib/modules/web3/transports.ts
+++ b/lib/modules/web3/transports.ts
@@ -5,7 +5,7 @@ import { fallback, http } from 'wagmi'
 import { getGqlChain } from '@/lib/config/app.config'
 import { SupportedChainId } from '@/lib/config/config.types'
 
-import { chains, rpcFallbacks, rpcOverrides } from './ChainConfig'
+import { chains, getDefaultRpcUrl, rpcFallbacks, rpcOverrides } from './ChainConfig'
 export function getTransports(chain: Chain) {
   const gqlChain = getGqlChain(chain.id as SupportedChainId)
   const overrideRpcUrl = rpcOverrides[gqlChain]
@@ -17,3 +17,8 @@ export function getTransports(chain: Chain) {
 export const transports = Object.fromEntries(
   chains.map(chain => [chain.id, getTransports(chain)])
 ) as Record<number, ReturnType<typeof getTransports>>
+
+export function getHandlerRpcUrl(chainId: number): string {
+  const gqlChain = getGqlChain(chainId)
+  return rpcOverrides[gqlChain] || rpcFallbacks[gqlChain] || getDefaultRpcUrl(chainId)
+}

--- a/lib/modules/web3/transports.ts
+++ b/lib/modules/web3/transports.ts
@@ -18,7 +18,7 @@ export const transports = Object.fromEntries(
   chains.map(chain => [chain.id, getTransports(chain)])
 ) as Record<number, ReturnType<typeof getTransports>>
 
-export function getHandlerRpcUrl(chainId: number): string {
+export function getRpcUrl(chainId: number): string {
   const gqlChain = getGqlChain(chainId)
   return rpcOverrides[gqlChain] || rpcFallbacks[gqlChain] || getDefaultRpcUrl(chainId)
 }

--- a/test/anvil/anvil-setup.ts
+++ b/test/anvil/anvil-setup.ts
@@ -85,16 +85,23 @@ export function getTestRpcSetup(networkName: NetworksWithFork) {
 }
 
 export function getForkUrl(network: NetworkSetup, verbose = false): string {
-  if (network.networkName === 'Ethereum' && process.env['NEXT_PRIVATE_INFURA_KEY']) {
-    return `https://mainnet.infura.io/v3/${process.env['NEXT_PRIVATE_INFURA_KEY']}`
-  } else {
-    if (!network.fallBackRpc) {
-      throw Error(`Please add a fallback RPC for ${network.networkName} network.`)
+  const privateInfuraKey = process.env['NEXT_PRIVATE_INFURA_KEY']
+  if (privateInfuraKey) {
+    if (network.networkName === 'Ethereum') {
+      return `https://mainnet.infura.io/v3/${privateInfuraKey}`
     }
-
-    if (verbose) {
-      console.warn(`Falling back to \`${network.fallBackRpc}\`.`)
+    if (network.networkName === 'Polygon') {
+      return `https://polygon-mainnet.infura.io/v3/${privateInfuraKey}`
     }
-    return network.fallBackRpc
+    if (network.networkName === 'Sepolia') return `https://sepolia.infura.io/v3/${privateInfuraKey}`
   }
+
+  if (!network.fallBackRpc) {
+    throw Error(`Please add a fallback RPC for ${network.networkName} network.`)
+  }
+
+  if (verbose) {
+    console.warn(`Falling back to \`${network.fallBackRpc}\`.`)
+  }
+  return network.fallBackRpc
 }

--- a/test/vitest/setup-integration.ts
+++ b/test/vitest/setup-integration.ts
@@ -1,9 +1,10 @@
 import { connectWithDefaultUser, disconnectDefaultUser } from '../utils/wagmi/wagmi-connections'
-import * as chainConfigModule from '../../lib/modules/web3/ChainConfig'
+import * as transportsModule from '../../lib/modules/web3/transports'
 import { NetworksWithFork, getTestRpcSetup } from '../anvil/anvil-setup'
 import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { createPublicClient, http } from 'viem'
 import { mainnetTest, polygonTest } from '../anvil/testWagmiConfig'
+import { chainsByKey } from '@/lib/modules/web3/ChainConfig'
 
 /*
   Specific setup for integration tests (that it is not needed in unit tests)
@@ -22,14 +23,12 @@ afterAll(async () => {
   Mocks getDefaultRpcUrl to return the test rpcUrl ('http://127.0.0.1:port/poolId')
   Keeps the rest of the module unmocked
 */
-vi.mock('../../lib/modules/web3/ChainConfig', async importOriginal => {
-  const originalModule = await importOriginal<typeof chainConfigModule>()
+vi.mock('../../lib/modules/web3/transports', async importOriginal => {
+  const originalModule = await importOriginal<typeof transportsModule>()
   return {
     ...originalModule,
-    getDefaultRpcUrl: (chainId: number) => {
-      const { rpcUrl } = getTestRpcSetup(
-        chainConfigModule.chainsByKey[chainId].name as NetworksWithFork
-      )
+    getHandlerRpcUrl: (chainId: number) => {
+      const { rpcUrl } = getTestRpcSetup(chainsByKey[chainId].name as NetworksWithFork)
       return rpcUrl
     },
   }

--- a/test/vitest/setup-integration.ts
+++ b/test/vitest/setup-integration.ts
@@ -27,7 +27,7 @@ vi.mock('../../lib/modules/web3/transports', async importOriginal => {
   const originalModule = await importOriginal<typeof transportsModule>()
   return {
     ...originalModule,
-    getHandlerRpcUrl: (chainId: number) => {
+    getRpcUrl: (chainId: number) => {
       const { rpcUrl } = getTestRpcSetup(chainsByKey[chainId].name as NetworksWithFork)
       return rpcUrl
     },


### PR DESCRIPTION
**Before:** 
Handlers were using `getDefaultRpcUrl()` which takes the viem's public rpc url. This could lead to errors due to 429s or temporary outages of the public URLs.

**After:** 
Handlers use `getHandlerRpcUrl()`which takes the rpc url from the transports setup, that is, uses private (or fallback) urls, that should be more reliable. 

With this change we should minimize errors like these ones: https://balancer-labs.sentry.io/issues/5763086985/

We are also using private infura url for integration tests (sepolia and polygon) to make them more reliable. 

