### PR TITLE
fix: improve price impact error handling

### DIFF
--- a/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -203,7 +203,8 @@ export function toPoolState(pool: Pool): PoolState {
   return {
     id: pool.id as Hex,
     address: pool.address as Address,
-    tokens: pool.poolTokens as MinimalToken[],
+    // Destruct to avoid errors when the SDK tries to mutate the poolTokens (read-only from GraphQL)
+    tokens: [...pool.poolTokens] as MinimalToken[],
     type: mapPoolType(pool.type),
     protocolVersion: pool.protocolVersion as ProtocolVersion,
   }

--- a/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -172,33 +172,35 @@ function AddLiquidityMainForm() {
             <TokenInputs tokenSelectDisclosureOpen={() => tokenSelectDisclosure.onOpen()} />
           )}
           <VStack spacing="sm" align="start" w="full">
-            <PriceImpactAccordion
-              isDisabled={!priceImpactQuery.data}
-              cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
-              setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
-              accordionButtonComponent={
-                <HStack>
-                  <Text variant="secondary" fontSize="sm" color="font.secondary">
-                    Price impact:{' '}
-                  </Text>
-                  {isFetching ? (
-                    <Skeleton w="40px" h="16px" />
-                  ) : (
-                    <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
-                      {priceImpactLabel}
+            {!simulationQuery.isError && (
+              <PriceImpactAccordion
+                isDisabled={!priceImpactQuery.data}
+                cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
+                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
+                accordionButtonComponent={
+                  <HStack>
+                    <Text variant="secondary" fontSize="sm" color="font.secondary">
+                      Price impact:{' '}
                     </Text>
-                  )}
-                </HStack>
-              }
-              accordionPanelComponent={
-                <PoolActionsPriceImpactDetails
-                  totalUSDValue={totalUSDValue}
-                  bptAmount={simulationQuery.data?.bptOut.amount}
-                  isAddLiquidity
-                  isLoading={isFetching}
-                />
-              }
-            />
+                    {isFetching ? (
+                      <Skeleton w="40px" h="16px" />
+                    ) : (
+                      <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
+                        {priceImpactLabel}
+                      </Text>
+                    )}
+                  </HStack>
+                }
+                accordionPanelComponent={
+                  <PoolActionsPriceImpactDetails
+                    totalUSDValue={totalUSDValue}
+                    bptAmount={simulationQuery.data?.bptOut.amount}
+                    isAddLiquidity
+                    isLoading={isFetching}
+                  />
+                }
+              />
+            )}
           </VStack>
           <Grid w="full" templateColumns="1fr 1fr" gap="sm">
             <GridItem>
@@ -225,7 +227,9 @@ function AddLiquidityMainForm() {
             </GridItem>
           </Grid>
           {showAcceptPoolRisks && <AddLiquidityFormCheckbox />}
-          {priceImpactQuery.isError && <PriceImpactError priceImpactQuery={priceImpactQuery} />}
+          {!simulationQuery.isError && priceImpactQuery.isError && (
+            <PriceImpactError priceImpactQuery={priceImpactQuery} />
+          )}
           {simulationQuery.isError && (
             <GenericError
               customErrorName={'Error in query simulation'}

--- a/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -152,31 +152,33 @@ export function RemoveLiquidityForm() {
               )}
             </VStack>
             <VStack spacing="sm" align="start" w="full">
-              <PriceImpactAccordion
-                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
-                accordionButtonComponent={
-                  <HStack>
-                    <Text variant="secondary" fontSize="sm" color="font.secondary">
-                      Price impact:{' '}
-                    </Text>
-                    {isFetching ? (
-                      <Skeleton w="40px" h="16px" />
-                    ) : (
-                      <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
-                        {priceImpactLabel}
+              {!simulationQuery.isError && (
+                <PriceImpactAccordion
+                  setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
+                  accordionButtonComponent={
+                    <HStack>
+                      <Text variant="secondary" fontSize="sm" color="font.secondary">
+                        Price impact:{' '}
                       </Text>
-                    )}
-                  </HStack>
-                }
-                accordionPanelComponent={
-                  <PoolActionsPriceImpactDetails
-                    totalUSDValue={totalUSDValue}
-                    bptAmount={BigInt(parseUnits(quoteBptIn, 18))}
-                    isLoading={isFetching}
-                  />
-                }
-                isDisabled={priceImpactQuery.isLoading && !priceImpactQuery.isSuccess}
-              />
+                      {isFetching ? (
+                        <Skeleton w="40px" h="16px" />
+                      ) : (
+                        <Text variant="secondary" fontSize="sm" color={priceImpactColor}>
+                          {priceImpactLabel}
+                        </Text>
+                      )}
+                    </HStack>
+                  }
+                  accordionPanelComponent={
+                    <PoolActionsPriceImpactDetails
+                      totalUSDValue={totalUSDValue}
+                      bptAmount={BigInt(parseUnits(quoteBptIn, 18))}
+                      isLoading={isFetching}
+                    />
+                  }
+                  isDisabled={priceImpactQuery.isLoading && !priceImpactQuery.isSuccess}
+                />
+              )}
             </VStack>
             <SimulationError simulationQuery={simulationQuery} />
             <Tooltip label={isDisabled ? disabledReason : ''}>

--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -48,13 +48,13 @@ export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Base]: getPrivateRpcUrl(GqlChain.Base),
   [GqlChain.Avalanche]: getPrivateRpcUrl(GqlChain.Avalanche),
   [GqlChain.Fantom]: getPrivateRpcUrl(GqlChain.Fantom),
-  [GqlChain.Gnosis]: undefined,
+  [GqlChain.Gnosis]: getPrivateRpcUrl(GqlChain.Gnosis),
   [GqlChain.Optimism]: getPrivateRpcUrl(GqlChain.Optimism),
   [GqlChain.Polygon]: getPrivateRpcUrl(GqlChain.Polygon),
   [GqlChain.Zkevm]: getPrivateRpcUrl(GqlChain.Zkevm),
   [GqlChain.Sepolia]: getPrivateRpcUrl(GqlChain.Sepolia),
   [GqlChain.Mode]: undefined,
-  [GqlChain.Fraxtal]: getPrivateRpcUrl(GqlChain.Fraxtal),
+  [GqlChain.Fraxtal]: undefined,
 }
 
 const customMainnet = { iconUrl: '/images/chains/MAINNET.svg', ...mainnet }

--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -48,13 +48,13 @@ export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Base]: getPrivateRpcUrl(GqlChain.Base),
   [GqlChain.Avalanche]: getPrivateRpcUrl(GqlChain.Avalanche),
   [GqlChain.Fantom]: getPrivateRpcUrl(GqlChain.Fantom),
-  [GqlChain.Gnosis]: getPrivateRpcUrl(GqlChain.Gnosis),
+  [GqlChain.Gnosis]: undefined,
   [GqlChain.Optimism]: getPrivateRpcUrl(GqlChain.Optimism),
   [GqlChain.Polygon]: getPrivateRpcUrl(GqlChain.Polygon),
   [GqlChain.Zkevm]: getPrivateRpcUrl(GqlChain.Zkevm),
   [GqlChain.Sepolia]: getPrivateRpcUrl(GqlChain.Sepolia),
   [GqlChain.Mode]: undefined,
-  [GqlChain.Fraxtal]: undefined,
+  [GqlChain.Fraxtal]: getPrivateRpcUrl(GqlChain.Fraxtal),
 }
 
 const customMainnet = { iconUrl: '/images/chains/MAINNET.svg', ...mainnet }

--- a/lib/shared/components/alerts/BalAlertLink.tsx
+++ b/lib/shared/components/alerts/BalAlertLink.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { Link, LinkProps } from '@chakra-ui/react'
+import { PropsWithChildren } from 'react'
+
+export function BalAlertLink({ href, children, ...rest }: PropsWithChildren<LinkProps>) {
+  return (
+    <Link href={href} variant="nav" color="white" target="_blank" {...rest}>
+      {children}
+    </Link>
+  )
+}

--- a/lib/shared/components/alerts/BalAlertLink.tsx
+++ b/lib/shared/components/alerts/BalAlertLink.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from 'react'
 
 export function BalAlertLink({ href, children, ...rest }: PropsWithChildren<LinkProps>) {
   return (
-    <Link href={href} variant="nav" color="white" target="_blank" {...rest}>
+    <Link href={href} color="font.dark" textDecoration="underline" target="_blank" {...rest}>
       {children}
     </Link>
   )

--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -2,8 +2,9 @@
 
 import { AlertProps, Text } from '@chakra-ui/react'
 import { ErrorAlert } from './ErrorAlert'
-import { isUserRejectedError } from '../../utils/error-filters'
+import { isUserRejectedError, isViemHttpFetchError } from '../../utils/error-filters'
 import { ensureError } from '../../utils/errors'
+import { BalAlertLink } from '../alerts/BalAlertLink'
 
 type ErrorWithOptionalShortMessage = Error & { shortMessage?: string }
 type Props = AlertProps & {
@@ -15,6 +16,18 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
   const error = ensureError(_error)
   if (isUserRejectedError(error)) return null
   const errorName = customErrorName ? `${customErrorName} (${error.name})` : error.name
+  if (isViemHttpFetchError(_error)) {
+    return (
+      <ErrorAlert title={customErrorName} {...rest}>
+        <Text variant="secondary" color="black">
+          It looks like there was a network issue. Check your connection and try again. You can
+          report the problem in our{' '}
+          <BalAlertLink href="https://discord.balancer.fi/">discord</BalAlertLink> if the issue
+          persists.
+        </Text>
+      </ErrorAlert>
+    )
+  }
   const errorMessage = error?.shortMessage || error.message
   return (
     <ErrorAlert title={errorName} {...rest}>

--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -21,8 +21,8 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
       <ErrorAlert title={customErrorName} {...rest}>
         <Text variant="secondary" color="black">
           It looks like there was a network issue. Check your connection and try again. You can
-          report the problem in our{' '}
-          <BalAlertLink href="https://discord.balancer.fi/">discord</BalAlertLink> if the issue
+          report the problem in{' '}
+          <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if the issue
           persists.
         </Text>
       </ErrorAlert>

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -1,3 +1,18 @@
 export function isUserRejectedError(error: Error): boolean {
   return error.message.startsWith('User rejected the request.')
 }
+
+/*
+  Detects "Failed to fetch" Http request errors thrown by wagmi/viem
+  These errors could be caused by different reasons, like network issues, CORS, 429 etc.
+*/
+export function isViemHttpFetchError(error?: Error | null): boolean {
+  if (!error) return false
+  if (
+    error?.message.startsWith('HTTP request failed.') &&
+    error?.message.includes('Failed to fetch')
+  ) {
+    return true
+  }
+  return false
+}

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -9,8 +9,8 @@ export function isUserRejectedError(error: Error): boolean {
 export function isViemHttpFetchError(error?: Error | null): boolean {
   if (!error) return false
   if (
-    error?.message.startsWith('HTTP request failed.') &&
-    error?.message.includes('Failed to fetch')
+    error.message.startsWith('HTTP request failed.') &&
+    error.message.includes('Failed to fetch')
   ) {
     return true
   }


### PR DESCRIPTION
Improves error handling in liquidity forms: 

- Avoids showing price impact error when there is also a simulation query error.
- Detects specific viem network error in generic error component.
- Avoids read-only issues in SDK.

Example of network error in Add form:

<img width="567" alt="networkError" src="https://github.com/user-attachments/assets/6986a598-f07a-4e2e-8f75-22d91a36a30e">



Example of Fraxtal error (already fixed) in Add form: 

<img width="555" alt="Fraxtal error" src="https://github.com/user-attachments/assets/724cf12e-1cf8-462a-8bd5-37a463395650">



