### PR TITLE
fix: Don't do mint calls for non bal reward gauges

### DIFF
--- a/lib/modules/pool/actions/claim/useClaimAllRewardsStep.tsx
+++ b/lib/modules/pool/actions/claim/useClaimAllRewardsStep.tsx
@@ -17,6 +17,7 @@ import { BalTokenRewardsResult } from '@/lib/modules/portfolio/PortfolioClaim/us
 import { ClaimableBalancesResult } from '@/lib/modules/portfolio/PortfolioClaim/useClaimableBalances'
 import { allClaimableGaugeAddressesFor } from '../../pool.helpers'
 import { ClaimablePool } from './ClaimProvider'
+import { Address } from 'viem'
 
 const claimAllRewardsStepId = 'claim-all-rewards'
 
@@ -47,13 +48,12 @@ export function useClaimAllRewardsStep({
   const gaugeAddresses = pools.flatMap(pool => allClaimableGaugeAddressesFor(pool))
   const shouldClaimMany = gaugeAddresses.length > 1
   const stakingService = selectStakingService(chain, stakingType)
-  const { data: claimData, isLoading } = useClaimCallDataQuery(
-    gaugeAddresses,
-    stakingService,
-    nonBalRewards.length > 0,
-    balRewards.length > 0,
-    isClaimQueryEnabled
-  )
+  const { data: claimData, isLoading } = useClaimCallDataQuery({
+    claimRewardGauges: nonBalRewards.map(r => r.gaugeAddress),
+    mintBalRewardGauges: balRewards.map(r => r.gaugeAddress as Address),
+    gaugeService: stakingService,
+    enabled: isClaimQueryEnabled,
+  })
 
   const labels: TransactionLabels = {
     init: `Claim${shouldClaimMany ? ' all' : ''}`,

--- a/lib/modules/pool/actions/claim/useClaimAllRewardsSteps.tsx
+++ b/lib/modules/pool/actions/claim/useClaimAllRewardsSteps.tsx
@@ -2,6 +2,8 @@ import { useApproveMinterStep } from '@/lib/modules/staking/gauge/useMinterAppro
 import { TransactionStep } from '@/lib/modules/transactions/transaction-steps/lib'
 import { useMemo } from 'react'
 import { ClaimAllRewardsStepParams, useClaimAllRewardsStep } from './useClaimAllRewardsStep'
+import { useApproveRelayerStep } from '@/lib/modules/relayer/useApproveRelayerStep'
+import { getChainId } from '@/lib/config/app.config'
 
 export function useClaimAllRewardsSteps(params: ClaimAllRewardsStepParams) {
   const pool = params.pools[0]
@@ -10,7 +12,10 @@ export function useClaimAllRewardsSteps(params: ClaimAllRewardsStepParams) {
   }
 
   const { chain } = pool
+  const chainId = getChainId(pool.chain)
 
+  const { step: relayerApprovalStep, isLoading: isLoadingRelayerApprovalStep } =
+    useApproveRelayerStep(chainId)
   const { step: minterApprovalStep, isLoading: isLoadingMinterApprovalStep } =
     useApproveMinterStep(chain)
 
@@ -18,15 +23,18 @@ export function useClaimAllRewardsSteps(params: ClaimAllRewardsStepParams) {
     useClaimAllRewardsStep(params)
 
   const steps = useMemo((): TransactionStep[] => {
-    const steps = [claimAllRewardsStep]
+    const steps = [relayerApprovalStep, claimAllRewardsStep]
+
     if (params.balTokenRewardsQuery.balRewardsData.length > 0) {
       steps.unshift(minterApprovalStep)
     }
+
     return steps
-  }, [claimAllRewardsStep, minterApprovalStep, params])
+  }, [relayerApprovalStep, claimAllRewardsStep, minterApprovalStep, params])
 
   return {
-    isLoading: isLoadingMinterApprovalStep || isLoadingClaimAllRewards,
+    isLoading:
+      isLoadingRelayerApprovalStep || isLoadingMinterApprovalStep || isLoadingClaimAllRewards,
     steps,
   }
 }

--- a/lib/modules/pool/actions/claim/useClaimCallDataQuery.ts
+++ b/lib/modules/pool/actions/claim/useClaimCallDataQuery.ts
@@ -1,31 +1,52 @@
 import { useQuery } from '@tanstack/react-query'
-import { Address } from 'viem'
+import { Address, Hex } from 'viem'
 import { GaugeService } from '@/lib/shared/services/staking/gauge.service'
+import { useMemo } from 'react'
 
-export function useClaimCallDataQuery(
-  gaugeAddresses: Address[],
-  gaugeService: GaugeService | undefined,
-  hasUnclaimedNonBalRewards: boolean,
-  hasUnclaimedBalRewards: boolean,
-  enabled = true
-) {
-  const inputData = {
-    hasUnclaimedNonBalRewards,
-    hasUnclaimedBalRewards,
-    gauges: gaugeAddresses,
-    outputReference: 0n,
-  }
+export function useClaimCallDataQuery({
+  claimRewardGauges,
+  mintBalRewardGauges,
+  gaugeService,
+  enabled = true,
+}: {
+  claimRewardGauges: Address[]
+  mintBalRewardGauges: Address[]
+  gaugeService: GaugeService | undefined
+  enabled?: boolean
+}) {
+  const allGauges = useMemo(() => {
+    return [...claimRewardGauges, ...mintBalRewardGauges]
+  }, [claimRewardGauges, mintBalRewardGauges])
 
-  const queryKey = ['claim', 'gauge', 'callData', inputData]
+  const queryKey = ['claim', 'gauge', 'callData', allGauges]
+
   const queryFn = (): `0x${string}`[] => {
     if (!gaugeService) return []
-    return gaugeService.getGaugeClaimRewardsContractCallData(inputData)
+
+    const calls: Hex[] = []
+
+    if (claimRewardGauges.length > 0) {
+      const claimRewardsCallData = gaugeService.getGaugeEncodeClaimRewardsCallData({
+        gauges: claimRewardGauges,
+      })
+      calls.push(claimRewardsCallData)
+    }
+
+    if (mintBalRewardGauges.length > 0) {
+      const mintCallData = gaugeService.getGaugeEncodeMintCallData({
+        gauges: mintBalRewardGauges,
+        outputReference: 0n,
+      })
+      calls.push(mintCallData)
+    }
+
+    return calls
   }
 
   const query = useQuery({
     queryKey,
     queryFn,
-    enabled: enabled && gaugeService && gaugeAddresses.length > 0,
+    enabled: enabled && gaugeService && allGauges.length > 0,
   })
 
   return {


### PR DESCRIPTION
We were trying to call the `gaugeMint` function for gauges that are not registered and don't have BAL rewards because all gaugeAddresses were being passed in as if they were the same. This PR splits them up into the appropriate groups:
- Gauges you want to claim non bal rewards for, and
- gauges you want to claim bal rewards for.

This isn't a complete full-proof solution because it seems you can also have gauges with BAL rewards where `gaugeMint` also can't be called, but that should be much more rare.