### PR TITLE
fix: avoid unwanted background simulation refetches

### DIFF
--- a/lib/modules/pool/actions/unstake/UnstakeProvider.tsx
+++ b/lib/modules/pool/actions/unstake/UnstakeProvider.tsx
@@ -7,7 +7,7 @@ import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { LABELS } from '@/lib/shared/labels'
 import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@/lib/shared/utils/functions/isDisabledWithReason'
-import { bn } from '@/lib/shared/utils/numbers'
+import { bn, isZero } from '@/lib/shared/utils/numbers'
 import { HumanAmount } from '@balancer/sdk'
 import { createContext, PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { PoolListItem } from '../../pool.types'
@@ -57,10 +57,12 @@ export function _useUnstake() {
 
   const unstakeTxHash = transactionSteps.lastTransaction?.result?.data?.transactionHash
 
-  const { isDisabled, disabledReason } = isDisabledWithReason([
-    !isConnected,
-    LABELS.walletNotConnected,
-  ])
+  const hasRewardAmounts = rewardAmounts.some(amount => !isZero(amount.humanAmount))
+
+  const { isDisabled, disabledReason } = isDisabledWithReason(
+    [!isConnected, LABELS.walletNotConnected],
+    [isZero(amountOut) && !hasRewardAmounts, "There's no staked amount to be unstaked"]
+  )
 
   /**
    * Side-effects

--- a/lib/modules/portfolio/PortfolioClaim/useBalRewards.tsx
+++ b/lib/modules/portfolio/PortfolioClaim/useBalRewards.tsx
@@ -14,7 +14,7 @@ import { ClaimablePool } from '../../pool/actions/claim/ClaimProvider'
 import { balancerV2GaugeV5Abi } from '../../web3/contracts/abi/generated'
 import { WriteContractParameters } from 'wagmi/actions'
 import { compact } from 'lodash'
-import { getClaimableQueryStaleTime } from '../../web3/contracts/wagmi-helpers'
+import { onlyExplicitRefetch } from '@/lib/shared/utils/queries'
 
 export interface BalTokenReward {
   balance: bigint
@@ -65,7 +65,11 @@ export function useBalTokenRewards(pools: ClaimablePool[]) {
   } = useReadContracts({
     allowFailure: true,
     contracts: contractCalls,
-    query: { enabled: isConnected && !!pools.length, staleTime: getClaimableQueryStaleTime() },
+    query: {
+      enabled: isConnected && !!pools.length,
+      // In chains like polygon, we don't want background refetches while waiting for min block confirmations
+      ...onlyExplicitRefetch,
+    },
   })
 
   const balRewardsData = useMemo(() => {

--- a/lib/modules/portfolio/PortfolioClaim/useBalRewards.tsx
+++ b/lib/modules/portfolio/PortfolioClaim/useBalRewards.tsx
@@ -14,6 +14,7 @@ import { ClaimablePool } from '../../pool/actions/claim/ClaimProvider'
 import { balancerV2GaugeV5Abi } from '../../web3/contracts/abi/generated'
 import { WriteContractParameters } from 'wagmi/actions'
 import { compact } from 'lodash'
+import { getClaimableQueryStaleTime } from '../../web3/contracts/wagmi-helpers'
 
 export interface BalTokenReward {
   balance: bigint
@@ -64,7 +65,7 @@ export function useBalTokenRewards(pools: ClaimablePool[]) {
   } = useReadContracts({
     allowFailure: true,
     contracts: contractCalls,
-    query: { enabled: isConnected && !!pools.length },
+    query: { enabled: isConnected && !!pools.length, staleTime: getClaimableQueryStaleTime() },
   })
 
   const balRewardsData = useMemo(() => {

--- a/lib/modules/portfolio/PortfolioClaim/useClaimableBalances.ts
+++ b/lib/modules/portfolio/PortfolioClaim/useClaimableBalances.ts
@@ -11,6 +11,7 @@ import { BPT_DECIMALS } from '../../pool/pool.constants'
 import { ClaimablePool } from '../../pool/actions/claim/ClaimProvider'
 import { GqlChain, GqlPoolStakingGaugeReward } from '@/lib/shared/services/api/generated/graphql'
 import { groupBy, uniqBy } from 'lodash'
+import { getClaimableQueryStaleTime } from '../../web3/contracts/wagmi-helpers'
 
 interface ClaimableRewardRef {
   tokenAddress: Address
@@ -76,7 +77,10 @@ export function useClaimableBalances(pools: ClaimablePool[]) {
 
   const { data, refetch, isLoading, status }: UseReadContractsReturnType = useReadContracts({
     contracts: claimableRewardContractCalls,
-    query: { enabled: isConnected },
+    query: {
+      enabled: isConnected,
+      staleTime: getClaimableQueryStaleTime(),
+    },
   })
 
   // Format claimable rewards data

--- a/lib/modules/portfolio/PortfolioClaim/useClaimableBalances.ts
+++ b/lib/modules/portfolio/PortfolioClaim/useClaimableBalances.ts
@@ -11,7 +11,7 @@ import { BPT_DECIMALS } from '../../pool/pool.constants'
 import { ClaimablePool } from '../../pool/actions/claim/ClaimProvider'
 import { GqlChain, GqlPoolStakingGaugeReward } from '@/lib/shared/services/api/generated/graphql'
 import { groupBy, uniqBy } from 'lodash'
-import { getClaimableQueryStaleTime } from '../../web3/contracts/wagmi-helpers'
+import { onlyExplicitRefetch } from '@/lib/shared/utils/queries'
 
 interface ClaimableRewardRef {
   tokenAddress: Address
@@ -79,7 +79,8 @@ export function useClaimableBalances(pools: ClaimablePool[]) {
     contracts: claimableRewardContractCalls,
     query: {
       enabled: isConnected,
-      staleTime: getClaimableQueryStaleTime(),
+      // In chains like polygon, we don't want background refetches while waiting for min block confirmations
+      ...onlyExplicitRefetch,
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -16,7 +16,7 @@ import { usdtAbi } from './abi/UsdtAbi'
 import { TransactionExecution, TransactionSimulation, WriteAbiMutability } from './contract.types'
 import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
-import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
 
 type Erc20Abi = typeof erc20Abi
 
@@ -60,6 +60,7 @@ export function useManagedErc20Transaction({
     query: {
       enabled: enabled && !shouldChangeNetwork,
       meta: simulationMeta,
+      staleTime: getTxSimulationStaleTime(),
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -16,7 +16,8 @@ import { usdtAbi } from './abi/UsdtAbi'
 import { TransactionExecution, TransactionSimulation, WriteAbiMutability } from './contract.types'
 import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
-import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { onlyExplicitRefetch } from '@/lib/shared/utils/queries'
 
 type Erc20Abi = typeof erc20Abi
 
@@ -60,7 +61,8 @@ export function useManagedErc20Transaction({
     query: {
       enabled: enabled && !shouldChangeNetwork,
       meta: simulationMeta,
-      staleTime: getTxSimulationStaleTime(),
+      // In chains like polygon, we don't want background refetches while waiting for min block confirmations
+      ...onlyExplicitRefetch,
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -17,7 +17,8 @@ import { useNetworkConfig } from '@/lib/config/useNetworkConfig'
 import { useRecentTransactions } from '../../transactions/RecentTransactionsProvider'
 import { mainnet } from 'viem/chains'
 import { useTxHash } from '../safe.hooks'
-import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { onlyExplicitRefetch } from '@/lib/shared/utils/queries'
 
 export type ManagedSendTransactionInput = {
   labels: TransactionLabels
@@ -41,8 +42,8 @@ export function useManagedSendTransaction({
     query: {
       enabled: !!txConfig && !shouldChangeNetwork,
       meta: gasEstimationMeta,
-      refetchOnWindowFocus: false,
-      staleTime: getTxSimulationStaleTime(),
+      // In chains like polygon, we don't want background refetches while waiting for min block confirmations
+      ...onlyExplicitRefetch,
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -17,7 +17,7 @@ import { useNetworkConfig } from '@/lib/config/useNetworkConfig'
 import { useRecentTransactions } from '../../transactions/RecentTransactionsProvider'
 import { mainnet } from 'viem/chains'
 import { useTxHash } from '../safe.hooks'
-import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
 
 export type ManagedSendTransactionInput = {
   labels: TransactionLabels
@@ -42,6 +42,7 @@ export function useManagedSendTransaction({
       enabled: !!txConfig && !shouldChangeNetwork,
       meta: gasEstimationMeta,
       refetchOnWindowFocus: false,
+      staleTime: getTxSimulationStaleTime(),
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -14,7 +14,8 @@ import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
 import { captureWagmiExecutionError } from '@/lib/shared/utils/query-errors'
 import { useTxHash } from '../safe.hooks'
-import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { onlyExplicitRefetch } from '@/lib/shared/utils/queries'
 
 type IAbiMap = typeof AbiMap
 type AbiMapKey = keyof typeof AbiMap
@@ -53,7 +54,8 @@ export function useManagedTransaction({
     query: {
       enabled: enabled && !shouldChangeNetwork,
       meta: txSimulationMeta,
-      staleTime: getTxSimulationStaleTime(),
+      // In chains like polygon, we don't want background refetches while waiting for min block confirmations
+      ...onlyExplicitRefetch,
     },
   })
 

--- a/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -14,7 +14,7 @@ import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
 import { captureWagmiExecutionError } from '@/lib/shared/utils/query-errors'
 import { useTxHash } from '../safe.hooks'
-import { getWaitForReceiptTimeout } from './wagmi-helpers'
+import { getTxSimulationStaleTime, getWaitForReceiptTimeout } from './wagmi-helpers'
 
 type IAbiMap = typeof AbiMap
 type AbiMapKey = keyof typeof AbiMap
@@ -53,6 +53,7 @@ export function useManagedTransaction({
     query: {
       enabled: enabled && !shouldChangeNetwork,
       meta: txSimulationMeta,
+      staleTime: getTxSimulationStaleTime(),
     },
   })
 

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -31,3 +31,25 @@ export function getWaitForReceiptTimeout(chainId: number) {
   // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
   return secs(15).toMs()
 }
+
+/*
+  For a given tx simulation, we don't want background refetches.
+  We already have an explicit timeout mechanism (see useShouldFreezeQuote) to run refetch queries every 30 seconds.
+
+  Example where background refetches can be harmful:
+    Polygon:
+    1. The user is waiting for a Tx confirmation and goes to another tab
+    2. The tx is confirmed but has less than minConfirmations
+    3. The user comes back to balancer tab, which triggers a background react-query for the simulation (only if staleTime: 0)
+    5. The new simulation background query fails cause the tx is already confirmed (we get misleading sentry errors cause there was not a real error)
+    6. The tx reaches > minConfirmations so the flow can be finished successfully (however, point 5. can temporarily alter the UI and send wrong Sentry logs)
+
+  Setting staleTime to infinity will avoid background refetches like the ones in the previous example.
+
+  More info:
+  https://wagmi.sh/react/api/hooks/useSimulateContract#staletime
+  https://tkdodo.eu/blog/practical-react-query
+*/
+export function getTxSimulationStaleTime() {
+  return Infinity
+}

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -31,34 +31,3 @@ export function getWaitForReceiptTimeout(chainId: number) {
   // In other chains there will be 3 retries of 15 seconds until we throw the timeout error
   return secs(15).toMs()
 }
-
-/*
-  For a given tx simulation, we don't want background refetches.
-  We already have an explicit timeout mechanism (see useShouldFreezeQuote) to run refetch queries every 30 seconds.
-
-  Example where background refetches can be harmful:
-    Polygon:
-    1. The user is waiting for a Tx confirmation and goes to another tab
-    2. The tx is confirmed but has less than minConfirmations
-    3. The user comes back to balancer tab, which triggers a background react-query for the simulation (only if staleTime: 0)
-    5. The new simulation background query fails cause the tx is already confirmed (we get misleading sentry errors cause there was not a real error)
-    6. The tx reaches > minConfirmations so the flow can be finished successfully (however, point 5. can temporarily alter the UI and send wrong Sentry logs)
-
-  Setting staleTime to infinity will avoid background refetches like the ones in the previous example.
-
-  More info:
-  https://wagmi.sh/react/api/hooks/useSimulateContract#staletime
-  https://tkdodo.eu/blog/practical-react-query
-*/
-export function getTxSimulationStaleTime() {
-  return Infinity
-}
-
-/*
-  See comments of getTxSimulationStaleTime above
-  This prevents issues in polygon when the user navigates away from the page while waiting for a tx confirmation.
-  If the unstake + claim has less than minConfirmations, claimed and rewards queries would be refetched and return zero claimable data, breaking the flow.
-*/
-export function getClaimableQueryStaleTime() {
-  return Infinity
-}

--- a/lib/modules/web3/contracts/wagmi-helpers.ts
+++ b/lib/modules/web3/contracts/wagmi-helpers.ts
@@ -53,3 +53,12 @@ export function getWaitForReceiptTimeout(chainId: number) {
 export function getTxSimulationStaleTime() {
   return Infinity
 }
+
+/*
+  See comments of getTxSimulationStaleTime above
+  This prevents issues in polygon when the user navigates away from the page while waiting for a tx confirmation.
+  If the unstake + claim has less than minConfirmations, claimed and rewards queries would be refetched and return zero claimable data, breaking the flow.
+*/
+export function getClaimableQueryStaleTime() {
+  return Infinity
+}

--- a/lib/shared/components/modals/ActionModalFooter.tsx
+++ b/lib/shared/components/modals/ActionModalFooter.tsx
@@ -75,7 +75,10 @@ export function ActionModalFooter({ isSuccess, currentStep, returnLabel, returnA
             transition={{ duration: 0.3 }}
             style={{ width: '100%' }}
           >
-            <VStack w="full">{currentStep.renderAction()}</VStack>
+            <VStack w="full">
+              {/* Keep currentStep?. optional chaining cause some edge cases require it */}
+              {currentStep?.renderAction()}
+            </VStack>
           </motion.div>
         )}
       </AnimatePresence>

--- a/lib/shared/utils/queries.ts
+++ b/lib/shared/utils/queries.ts
@@ -1,6 +1,22 @@
 import { UseQueryResult } from '@tanstack/react-query'
 
-// When you only want a query to refetch when the key changes or refetch is called.
+/*
+  When you only want a query to refetch when the key changes or refetch is explicitly called.
+
+  Why no background refetches?  Example where background refetches can be harmful:
+    Polygon:
+    1. The user is waiting for a Tx confirmation and goes to another tab
+    2. The tx is confirmed but has less than minConfirmations
+    3. The user comes back to balancer tab, which triggers a background react-query for the simulation (only if staleTime: 0)
+    5. The new simulation background query fails cause the tx is already confirmed (we get misleading sentry errors cause there was not a real error)
+    6. The tx reaches > minConfirmations so the flow can be finished successfully (however, point 5. can temporarily alter the UI and send wrong Sentry logs)
+
+  Setting refetchOnWindowFocus to false will avoid background refetches like the ones in the previous example.
+
+  More info:
+  https://tanstack.com/query/v5/docs/framework/react/guides/window-focus-refetching
+  https://tkdodo.eu/blog/practical-react-query
+*/
 export const onlyExplicitRefetch = {
   refetchOnMount: false,
   refetchOnReconnect: false,


### PR DESCRIPTION
The reason of this PR is explained in this comment: https://github.com/balancer/frontend-v3/pull/1082/files#diff-513339dcf8a351b65d33cd277aa6442c85248d22a53b788aa262c7e2e5fddb36R34

This was previously solved with `placeholderData` option in the `queryClient` but that was causing other issues, so we had to remove that setup. 

**How to reproduce:** 
Example with `Claim and Unstake` flow 
You can reproduce it in `main branch` if you have something to claim in a staked pool in **polygon**

1. Remove this code from` react-query.provider.tsx` (it was causing other issues and it will be deleted as part of the current PR)
```ts
queryClient.setDefaultOptions({
  queries: {
    /* Avoids problems in simulation and build queries when the user navigates away from the page while waiting for a tx confirmation.
      Without this option, navigating to another tab and coming back was causing useRemoveLiquidityBuildCallDataQuery to be undefined leading to unexpected thrown errors.

      This is equivalent to setting the old keepPreviousData: true option
      More info:
        https://github.com/TanStack/query/discussions/6460
    */
    placeholderData: (prev: any) => prev,
  },
})
```
2. Trigger the “Claim and unstake” tx, confirm in your wallet and go between balancer and other browser tabs back and forth until you get this behaviour:

https://github.com/user-attachments/assets/0ef53fd8-8327-4a2d-9d8e-467679ed8864




