### PR TITLE
fix: remove liquidity fixes

### DIFF
--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -215,11 +215,12 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
   )
 
   const totalUSDValue: string = safeSum(Object.values(usdAmountOutMap))
+  const totalAmountsOut: string = safeSum(quoteAmountsOut.map(a => a.amount))
 
   const { isDisabled, disabledReason } = isDisabledWithReason(
     [!isConnected, LABELS.walletNotConnected],
     [Number(humanBptIn) === 0, 'You must specify a valid bpt in'],
-    [isZero(totalUSDValue), 'Amount to remove cannot be zero'],
+    [isZero(totalAmountsOut), 'Amount to remove cannot be zero'],
     [needsToAcceptHighPI, 'Accept high price impact first'],
     [simulationQuery.isLoading, 'Fetching quote...'],
     [simulationQuery.isError, 'Error fetching quote'],

--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -7,7 +7,7 @@ import { LABELS } from '@/lib/shared/labels'
 import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@/lib/shared/utils/functions/isDisabledWithReason'
-import { bn, safeSum } from '@/lib/shared/utils/numbers'
+import { bn, isZero, safeSum } from '@/lib/shared/utils/numbers'
 import { HumanAmount, TokenAmount, isSameAddress } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useEffect, useMemo, useState } from 'react'
 import { usePool } from '../../PoolProvider'
@@ -112,6 +112,9 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
 
   const singleTokenOutAddress = singleTokenAddress || firstTokenAddress
 
+  const tokenOut =
+    wethIsEth && wNativeAsset ? (wNativeAsset.address as Address) : singleTokenOutAddress
+
   /**
    * Queries
    */
@@ -120,8 +123,8 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
     poolId: pool.id,
     chainId,
     humanBptIn,
-    tokenOut: wethIsEth && wNativeAsset ? (wNativeAsset.address as Address) : singleTokenOutAddress,
-    enabled: !urlTxHash,
+    tokenOut,
+    enabled: !urlTxHash && !!tokenOut,
   })
 
   const priceImpactQuery = useRemoveLiquidityPriceImpactQuery({
@@ -129,8 +132,8 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
     poolId: pool.id,
     chainId,
     humanBptIn,
-    tokenOut: wethIsEth && wNativeAsset ? (wNativeAsset.address as Address) : singleTokenOutAddress,
-    enabled: !urlTxHash,
+    tokenOut,
+    enabled: !urlTxHash && !!tokenOut,
   })
 
   /**
@@ -216,6 +219,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
   const { isDisabled, disabledReason } = isDisabledWithReason(
     [!isConnected, LABELS.walletNotConnected],
     [Number(humanBptIn) === 0, 'You must specify a valid bpt in'],
+    [isZero(totalUSDValue), 'Amount to remove cannot be zero'],
     [needsToAcceptHighPI, 'Accept high price impact first'],
     [simulationQuery.isLoading, 'Fetching quote...'],
     [simulationQuery.isError, 'Error fetching quote'],

--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -30,7 +30,7 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
   }
   const errorMessage = error?.shortMessage || error.message
 
-  if (errorMessage === 'RPC Request failed.') {
+  if (errorMessage === 'RPC Request failed.' || errorMessage === 'An unknown RPC error occurred.') {
     return (
       <ErrorAlert title={errorMessage} {...rest}>
         <Text variant="secondary" color="black">

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -217,7 +217,6 @@ export function captureSentryError(
   e: unknown,
   { context, errorMessage, errorName }: SentryMetadata
 ) {
-  console.log('Context en captureSentryError', context)
   const causeError = ensureError(e)
   if (isUserRejectedError(causeError)) return
 
@@ -347,7 +346,7 @@ function sentryStackFramesToString(sentryStack?: SentryStack): string {
   )
 }
 
-export function getTenderlyUrl(sentryExtras?: Extras) {
-  if (!sentryExtras) return
-  return sentryExtras.tenderlyUrl as string | undefined
+export function getTenderlyUrl(sentryMetadata?: SentryMetadata) {
+  if (!sentryMetadata) return
+  return sentryMetadata?.context?.extra?.tenderlyUrl as string | undefined
 }


### PR DESCRIPTION
Remove liquidity fixes: 
- Disables next button when there's no amount out
- Disables queries when tokenOut is not defined as it should always exists if there are tokens in the pool. This should fix [this sentry issue](https://balancer-labs.sentry.io/issues/5718946329/?project=4506382607712256) or give us more clues about the real root cause. 
- Improves error handling  (tenderly urls and alert when we get `An unknown RPC error occurred.`)