### PR TITLE
chore: rename PRIVATE_ALCHEMY_KEY to NEXT_PRIVATE_ALCHEMY_KEY

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ on:
 env:
   NEXT_PUBLIC_BALANCER_API_URL: https://api-v3.balancer.fi/graphql
   NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
-  PRIVATE_ALCHEMY_KEY: ${{ secrets.PRIVATE_ALCHEMY_KEY }}
+  NEXT_PRIVATE_ALCHEMY_KEY: ${{ secrets.PRIVATE_ALCHEMY_KEY }}
 
 jobs:
   Build:

--- a/app/api/rpc/[chain]/route.ts
+++ b/app/api/rpc/[chain]/route.ts
@@ -6,7 +6,7 @@ type Params = {
   }
 }
 
-const ALCHEMY_KEY = process.env.PRIVATE_ALCHEMY_KEY || ''
+const ALCHEMY_KEY = process.env.NEXT_PRIVATE_ALCHEMY_KEY || ''
 
 const chainToRpcMap: Record<GqlChain, string | undefined> = {
   [GqlChain.Mainnet]: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
@@ -35,7 +35,7 @@ function getRpcUrl(chain: string) {
 
 export async function POST(request: Request, { params: { chain } }: Params) {
   if (!ALCHEMY_KEY) {
-    return new Response(JSON.stringify({ error: 'PRIVATE_ALCHEMY_KEY is missing' }), {
+    return new Response(JSON.stringify({ error: 'NEXT_PRIVATE_ALCHEMY_KEY is missing' }), {
       status: 500,
     })
   }

--- a/test/anvil/anvil-setup.ts
+++ b/test/anvil/anvil-setup.ts
@@ -85,7 +85,7 @@ export function getTestRpcSetup(networkName: NetworksWithFork) {
 }
 
 export function getForkUrl(network: NetworkSetup, verbose = false): string {
-  const privateAlchemyKey = process.env['PRIVATE_ALCHEMY_KEY']
+  const privateAlchemyKey = process.env['NEXT_PRIVATE_ALCHEMY_KEY']
   if (privateAlchemyKey) {
     if (network.networkName === 'Ethereum') {
       return `https://eth-mainnet.g.alchemy.com/v2/${privateAlchemyKey}`


### PR DESCRIPTION
Using NEXT prefix simplifies setup of vitest integration tests.
Note the name of the env var in github secrets remains the same (`PRIVATE_ALCHEMY_KEY`)