### PR TITLE
Update sparkles star system to differentiate between different yield types

### DIFF
--- a/lib/shared/components/icons/StarIcon.tsx
+++ b/lib/shared/components/icons/StarIcon.tsx
@@ -1,0 +1,49 @@
+import { useTheme } from '@chakra-ui/react'
+import { SVGProps } from 'react'
+
+interface Props extends SVGProps<SVGSVGElement> {
+  gradFrom?: string
+  gradTo?: string
+  variant?: 'gradient' | 'solid'
+  id?: string
+}
+
+function StarIcon({
+  gradFrom = 'yellow',
+  gradTo = 'pink',
+  variant = 'gradient',
+  id,
+  ...rest
+}: Props) {
+  const theme = useTheme()
+  const gradientId = `stars-gradient-${gradFrom}-${gradTo}-${id}`
+
+  const startColor = theme.colors[gradTo] ? theme.colors[gradTo]['500'] : gradTo
+  const stopColor = theme.colors[gradFrom] ? theme.colors[gradFrom]['500'] : gradFrom
+  return (
+    <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="24"
+          y1="-11.5"
+          x2="2.7273"
+          y2="16.3182"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor={startColor} />
+          <stop offset="1" stopColor={stopColor} />
+        </linearGradient>
+      </defs>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        // eslint-disable-next-line max-len
+        d="M11.888 8.974a4.726 4.726 0 0 0-2.913 2.914l-.885 2.548a.094.094 0 0 1-.18 0l-.885-2.548a4.726 4.726 0 0 0-2.913-2.914L1.563 8.09a.095.095 0 0 1 0-.178l2.549-.885a4.726 4.726 0 0 0 2.913-2.914l.885-2.548a.095.095 0 0 1 .18 0l.885 2.548a4.726 4.726 0 0 0 2.913 2.914l2.549.885a.095.095 0 0 1 0 .178l-2.549.885Z"
+        fill={variant === 'gradient' ? `url(#${gradientId})` : 'currentColor'}
+      />
+    </svg>
+  )
+}
+
+export default StarIcon

--- a/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
+++ b/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
@@ -7,7 +7,7 @@ import {
   PopoverContent,
   Text,
   TextProps,
-  useTheme,
+  useColorModeValue,
 } from '@chakra-ui/react'
 import BaseAprTooltip, { BaseAprTooltipProps } from './BaseAprTooltip'
 import { Info } from 'react-feather'
@@ -42,24 +42,50 @@ export const SparklesIcon = ({
   pool: Pool | PoolListItem | FeaturedPool
   id?: string
 }) => {
-  const theme = useTheme()
   const { corePoolId } = getProjectConfig()
   const hoverColor = isLBP(pool.type) ? 'inherit' : 'font.highlight'
 
   const hasRewardApr =
     pool.dynamicData.aprItems.filter(item => item.type !== GqlPoolAprItemType.SwapFee).length > 0
 
-  let gradFromColor = theme.colors.sparkles.default.from
-  let gradToColor = theme.colors.sparkles.default.to
+  const defaultGradFrom = useColorModeValue(
+    '#91A1B6', // light from
+    '#A0AEC0' // dark from
+  )
+  const defaultGradTo = useColorModeValue(
+    '#BCCCE1', // light to
+    '#E9EEF5' // dark to
+  )
+
+  const corePoolGradFrom = useColorModeValue(
+    '#BFA672', // light from
+    '#AE8C56' // dark from
+  )
+  const corePoolGradTo = useColorModeValue(
+    '#D9C47F', // light to
+    '#F4EAD2' // dark to
+  )
+
+  const rewardsGradFrom = useColorModeValue(
+    '#F49A55', // light from
+    '#F48975' // dark from
+  )
+  const rewardsGradTo = useColorModeValue(
+    '#FCD45B', // light to
+    '#EFB473' // dark to
+  )
+
+  let gradFromColor = defaultGradFrom
+  let gradToColor = defaultGradTo
 
   if (pool.id === corePoolId) {
-    gradFromColor = theme.colors.sparkles.corePool.from
-    gradToColor = theme.colors.sparkles.corePool.to
+    gradFromColor = corePoolGradFrom
+    gradToColor = corePoolGradTo
   }
 
   if (hasRewardApr) {
-    gradFromColor = theme.colors.sparkles.rewards.from
-    gradToColor = theme.colors.sparkles.rewards.to
+    gradFromColor = rewardsGradFrom
+    gradToColor = rewardsGradTo
   }
 
   return (

--- a/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
+++ b/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
@@ -75,11 +75,11 @@ export const SparklesIcon = ({
 
   const rewardsGradFrom = useColorModeValue(
     '#F49A55', // light from
-    '#F48975' // dark from
+    '#F49175' // dark from
   )
   const rewardsGradTo = useColorModeValue(
     '#FCD45B', // light to
-    '#EFB473' // dark to
+    '#FFCC33' // dark to
   )
 
   let gradFromColor = defaultGradFrom

--- a/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
+++ b/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
@@ -18,6 +18,7 @@ import { FeaturedPool, Pool } from '@/lib/modules/pool/PoolProvider'
 import { isLBP } from '@/lib/modules/pool/pool.helpers'
 import { getProjectConfig } from '@/lib/config/getProjectConfig'
 import { GqlPoolAprItemType } from '@/lib/shared/services/api/generated/graphql'
+import StarIcon from '../../icons/StarIcon'
 
 interface Props
   extends Omit<
@@ -46,7 +47,13 @@ export const SparklesIcon = ({
   const hoverColor = isLBP(pool.type) ? 'inherit' : 'font.highlight'
 
   const hasRewardApr =
-    pool.dynamicData.aprItems.filter(item => item.type !== GqlPoolAprItemType.SwapFee).length > 0
+    pool.dynamicData.aprItems.filter(item =>
+      [GqlPoolAprItemType.Staking, GqlPoolAprItemType.VebalEmissions].includes(item.type)
+    ).length > 0
+
+  const hasOnlySwapApr =
+    pool.dynamicData.aprItems.filter(item => item.type === GqlPoolAprItemType.SwapFee).length ===
+    pool.dynamicData.aprItems.length
 
   const defaultGradFrom = useColorModeValue(
     '#91A1B6', // light from
@@ -93,6 +100,14 @@ export const SparklesIcon = ({
       <Center w="16px">
         {isLBP(pool.type) ? (
           <Icon as={Info} boxSize={4} color={isOpen ? hoverColor : 'gray.400'} />
+        ) : hasOnlySwapApr ? (
+          <Icon
+            as={StarIcon}
+            boxSize={4}
+            gradFrom={isOpen ? 'green' : defaultGradFrom}
+            gradTo={isOpen ? 'green' : defaultGradTo}
+            id={id || ''}
+          />
         ) : (
           <Icon
             as={StarsIcon}


### PR DESCRIPTION
1.  Added new light and dark mode sparkles colors
2. Added new 'Single star' to display pool's with swap fees only
3. Single star icon
    - Assigned new single star icon `StarIcon.tsx` to display only when a pool has no other yield beyond swap fees. 
    - Use the gray colors already defined in the `defaultGrad`
4. Gray sparkles icon
    - This icon with the usual 3 stars should be assigned to any pool with yield in addition to swap fees, but with no staking yield. 
5. Orange sparkles
    - This will now only be used to denote pools with staking incentives (could be BAL or other staking incentives)
6. Gold sparkles icon
    - Bring back the gold sparkles icon for the BAL / WETH 80/20 pool (it got lost with the recent API update)
  