### PR TITLE
fix: filter undefined tokens from getPoolTokens

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import { useTokens } from '@/lib/modules/tokens/TokensProvider'
-import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
 import { useMandatoryContext } from '@/lib/shared/utils/contexts'
 import { HumanAmount } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useEffect, useMemo, useState } from 'react'
@@ -17,7 +16,6 @@ import {
   injectNativeAsset,
   replaceWrappedWithNativeAsset,
   requiresProportionalInput,
-  supportsNestedActions,
 } from '../LiquidityActionHelpers'
 import { isDisabledWithReason } from '@/lib/shared/utils/functions/isDisabledWithReason'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
@@ -30,7 +28,7 @@ import { useTotalUsdValue } from '@/lib/modules/tokens/useTotalUsdValue'
 import { HumanTokenAmountWithAddress } from '@/lib/modules/tokens/token.types'
 import { isUnhandledAddPriceImpactError } from '@/lib/modules/price-impact/price-impact.utils'
 import { useModalWithPoolRedirect } from '../../useModalWithPoolRedirect'
-import { getLeafTokens } from '@/lib/modules/tokens/token.helpers'
+import { getPoolTokens } from '../../pool.helpers'
 
 export type UseAddLiquidityResponse = ReturnType<typeof _useAddLiquidity>
 export const AddLiquidityContext = createContext<UseAddLiquidityResponse | null>(null)
@@ -59,8 +57,10 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
   const nativeAsset = getNativeAssetToken(chain)
   const wNativeAsset = getWrappedNativeAssetToken(chain)
 
+  const tokens = getPoolTokens(pool, getToken)
+
   function setInitialHumanAmountsIn() {
-    const amountsIn = getPoolTokens().map(
+    const amountsIn = tokens.map(
       token =>
         ({
           tokenAddress: token.address,
@@ -80,18 +80,6 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
       },
     ])
   }
-
-  function getPoolTokens() {
-    if (supportsNestedActions(pool)) {
-      return getLeafTokens(pool.poolTokens)
-    }
-
-    return pool.poolTokens
-  }
-
-  const tokens = getPoolTokens()
-    .map(token => getToken(token.address, chain))
-    .filter((token): token is GqlToken => !!token)
 
   const tokensWithNativeAsset = replaceWrappedWithNativeAsset(tokens, nativeAsset)
 

--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -75,7 +75,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
 
   function getPoolTokens(): GqlToken[] {
     type PoolToken = Pool['poolTokens'][0]
-    function getValidTokens(tokens: PoolToken[]): GqlToken[] {
+    function toGqlTokens(tokens: PoolToken[]): GqlToken[] {
       return tokens
         .map(token => getToken(token.address, pool.chain))
         .filter((token): token is GqlToken => token !== undefined)
@@ -84,10 +84,10 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
     // TODO add exception for composable pools where we can allow adding
     // liquidity with nested tokens
     if (supportsNestedActions(pool)) {
-      getValidTokens(getLeafTokens(pool.poolTokens))
+      toGqlTokens(getLeafTokens(pool.poolTokens))
     }
 
-    return getValidTokens(pool.poolTokens)
+    return toGqlTokens(pool.poolTokens)
   }
 
   const tokens = getPoolTokens()

--- a/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -81,7 +81,9 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
     return pool.poolTokens
   }
 
-  const tokens = getPoolTokens().map(token => getToken(token.address, pool.chain))
+  const tokens = getPoolTokens()
+    .map(token => getToken(token.address, pool.chain))
+    .filter((token): token is GqlToken => token !== undefined)
 
   function tokensToShow() {
     // Cow AMM pools don't support wethIsEth

--- a/lib/modules/pool/pool.helpers.spec.ts
+++ b/lib/modules/pool/pool.helpers.spec.ts
@@ -1,0 +1,131 @@
+/* eslint-disable max-len */
+import { GqlToken } from '@/lib/shared/services/api/generated/graphql'
+import { isSameAddress } from '@/lib/shared/utils/addresses'
+import { Pool } from './PoolProvider'
+import { getPoolTokens } from './pool.helpers'
+
+describe('getPoolTokens', () => {
+  it('when pool supports nested actions', () => {
+    const pool = {
+      id: '0x66888e4f35063ad8bb11506a6fde5024fb4f1db0000100000000000000000053',
+      address: '0x2086f52651837600180de173b09470f54ef74910',
+      chain: 'GNOSIS',
+      poolTokens: [
+        {
+          address: '0x2086f52651837600180de173b09470f54ef74910',
+          symbol: 'staBAL3',
+          hasNestedPool: true,
+          nestedPool: {
+            address: '0x2086f52651837600180de173b09470f54ef74910',
+            symbol: 'staBAL3',
+            tokens: [
+              {
+                address: '0x2086f52651837600180de173b09470f54ef74910',
+                symbol: 'staBAL3',
+              },
+              {
+                address: '0x4ecaba5870353805a9f068101a40e0f32ed605c6',
+                symbol: 'USDT',
+              },
+              {
+                address: '0xddafbb505ad214d7b80b1f830fccc89b60fb7a83',
+                symbol: 'USDC',
+              },
+              {
+                address: '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d',
+                symbol: 'WXDAI',
+              },
+            ],
+          },
+        },
+        {
+          address: '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1',
+          symbol: 'WETH',
+          hasNestedPool: false,
+          nestedPool: null,
+        },
+        {
+          address: '0x8e5bbbb09ed1ebde8674cda39a0c169401db4252',
+          symbol: 'WBTC',
+          hasNestedPool: false,
+          nestedPool: null,
+        },
+      ],
+    } as unknown as Pool
+
+    const result = getPoolTokens(pool, getTokenMock(pool))
+    expect(result.map(t => t.symbol)).toEqual(['USDT', 'USDC', 'WXDAI', 'WETH', 'WBTC']) // contains 'staBAL3' nested tokens (USDT, USDC, WXDAI)
+  })
+
+  it('when pool does not support nested actions', () => {
+    const pool = {
+      id: '0xdacf5fa19b1f720111609043ac67a9818262850c000000000000000000000635',
+      address: '0xdacf5fa19b1f720111609043ac67a9818262850c',
+      chain: 'MAINNET',
+      poolTokens: [
+        {
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          hasNestedPool: false,
+          nestedPool: null,
+        },
+        {
+          address: '0xdacf5fa19b1f720111609043ac67a9818262850c',
+          symbol: 'osETH/wETH-BPT',
+          hasNestedPool: true,
+          nestedPool: {
+            address: '0xdacf5fa19b1f720111609043ac67a9818262850c',
+            symbol: 'osETH/wETH-BPT',
+            tokens: [
+              {
+                address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                symbol: 'WETH',
+              },
+              {
+                address: '0xdacf5fa19b1f720111609043ac67a9818262850c',
+                symbol: 'osETH/wETH-BPT',
+              },
+              {
+                address: '0xf1c9acdc66974dfb6decb12aa385b9cd01190e38',
+                symbol: 'osETH',
+              },
+            ],
+          },
+        },
+        {
+          address: '0xf1c9acdc66974dfb6decb12aa385b9cd01190e38',
+          symbol: 'osETH',
+          hasNestedPool: false,
+          nestedPool: null,
+        },
+      ],
+    } as unknown as Pool
+
+    const result = getPoolTokens(pool, getTokenMock(pool))
+    expect(result.map(t => t.symbol)).toEqual(['WETH', 'osETH']) // excludes 'osETH/wETH-BPT' bpt token
+  })
+})
+
+function getTokenMock(pool: Pool) {
+  const getAllTokens = (pool: Pool): GqlToken[] => {
+    const tokens: GqlToken[] = []
+
+    pool.poolTokens.forEach(poolToken => {
+      tokens.push({ address: poolToken.address, symbol: poolToken.symbol } as unknown as GqlToken)
+
+      if (poolToken.hasNestedPool && poolToken.nestedPool) {
+        poolToken.nestedPool.tokens.forEach(nestedToken => {
+          tokens.push(nestedToken as unknown as GqlToken)
+        })
+      }
+    })
+
+    return tokens
+  }
+  // Returns a getToken mock function that looks for a token by address in the whole pool structure (including nested pools)
+  return function (address: string): GqlToken | undefined {
+    return getAllTokens(pool).find(token =>
+      isSameAddress(token.address, address)
+    ) as unknown as GqlToken
+  }
+}

--- a/lib/modules/pool/pool.helpers.ts
+++ b/lib/modules/pool/pool.helpers.ts
@@ -334,7 +334,7 @@ export function getPoolTokens(
   type PoolToken = Pool['poolTokens'][0]
   function toGqlTokens(tokens: PoolToken[]): GqlToken[] {
     return tokens
-      .filter(token => !isSameAddress(token.address, pool.address))
+      .filter(token => !isSameAddress(token.address, pool.address)) // Exclude the BPT pool token itself
       .map(token => getToken(token.address, pool.chain))
       .filter((token): token is GqlToken => token !== undefined)
   }

--- a/lib/modules/pool/pool.helpers.ts
+++ b/lib/modules/pool/pool.helpers.ts
@@ -341,7 +341,7 @@ export function getPoolTokens(
   // TODO add exception for composable pools where we can allow adding
   // liquidity with nested tokens
   if (supportsNestedActions(pool)) {
-    toGqlTokens(getLeafTokens(pool.poolTokens))
+    return toGqlTokens(getLeafTokens(pool.poolTokens))
   }
 
   return toGqlTokens(pool.poolTokens)

--- a/lib/modules/pool/pool.helpers.ts
+++ b/lib/modules/pool/pool.helpers.ts
@@ -334,6 +334,7 @@ export function getPoolTokens(
   type PoolToken = Pool['poolTokens'][0]
   function toGqlTokens(tokens: PoolToken[]): GqlToken[] {
     return tokens
+      .filter(token => !isSameAddress(token.address, pool.address))
       .map(token => getToken(token.address, pool.chain))
       .filter((token): token is GqlToken => token !== undefined)
   }

--- a/lib/modules/pool/pool.helpers.ts
+++ b/lib/modules/pool/pool.helpers.ts
@@ -9,6 +9,7 @@ import {
   GqlPoolStakingOtherGauge,
   GqlPoolTokenDetail,
   GqlPoolType,
+  GqlToken,
 } from '@/lib/shared/services/api/generated/graphql'
 import { isSameAddress } from '@/lib/shared/utils/addresses'
 import { Numberish, bn } from '@/lib/shared/utils/numbers'
@@ -23,6 +24,8 @@ import { getUserTotalBalanceInt } from './user-balance.helpers'
 import { dateToUnixTimestamp } from '@/lib/shared/utils/time'
 import { balancerV2VaultAbi } from '../web3/contracts/abi/generated'
 import { balancerV3VaultAbi } from '../web3/contracts/abi/balancerV3VaultAbi'
+import { supportsNestedActions } from './actions/LiquidityActionHelpers'
+import { getLeafTokens } from '../tokens/token.helpers'
 
 /**
  * METHODS
@@ -322,4 +325,24 @@ export function requiresPermit2Approval(pool: Pool): boolean {
 
 export function getRateProviderWarnings(warnings: string[]) {
   return warnings.filter(warning => !isEmpty(warning))
+}
+
+export function getPoolTokens(
+  pool: Pool,
+  getToken: (address: string, chain: GqlChain) => GqlToken | undefined
+): GqlToken[] {
+  type PoolToken = Pool['poolTokens'][0]
+  function toGqlTokens(tokens: PoolToken[]): GqlToken[] {
+    return tokens
+      .map(token => getToken(token.address, pool.chain))
+      .filter((token): token is GqlToken => token !== undefined)
+  }
+
+  // TODO add exception for composable pools where we can allow adding
+  // liquidity with nested tokens
+  if (supportsNestedActions(pool)) {
+    toGqlTokens(getLeafTokens(pool.poolTokens))
+  }
+
+  return toGqlTokens(pool.poolTokens)
 }


### PR DESCRIPTION
Extracts `getPoolTokens` function to get a list of `GqlToken[]` from `pool.poolTokens`

- The new function keeps the `supportsNestedActions` feature
- Excludes top level BPT token
- Filters undefined values

These changes fix 2 issues: 

#### 1. Proportional removal not loading due to `undefined` first token in Remove provider:
![image_720](https://github.com/user-attachments/assets/2d58ee6d-4037-4165-b046-0366f10407c4)

#### 2. Add liquidity showing bpt tokens
Pool example: pools/ethereum/v2/0xdacf5fa19b1f720111609043ac67a9818262850c000000000000000000000635/add-liquidity

**Before**: 

<img width="474" alt="Before" src="https://github.com/user-attachments/assets/397e06b0-9aee-426f-acd7-c50e3dad371e">


**After**:
<img width="525" alt="after" src="https://github.com/user-attachments/assets/b143957a-483a-4362-9048-c936d31071d9">

