### PR TITLE
fix: show pi for add liquidity w/o connected wallet

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
+++ b/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
@@ -21,7 +21,7 @@ type Params = {
 
 export function useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabled }: Params) {
   const { pool, chainId } = usePool()
-  const { userAddress, isConnected } = useUserAccount()
+  const { userAddress } = useUserAccount()
   const { slippage } = useUserSettings()
   const debouncedHumanAmountsIn = useDebounce(humanAmountsIn, defaultDebounceMs)[0]
   const { data: blockNumber } = useBlockNumber({ chainId })
@@ -42,7 +42,7 @@ export function useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabl
   return useQuery({
     queryKey,
     queryFn,
-    enabled: enabled && isConnected && !areEmptyAmounts(debouncedHumanAmountsIn),
+    enabled: enabled && !areEmptyAmounts(debouncedHumanAmountsIn),
     gcTime: 0,
     meta: sentryMetaForAddLiquidityHandler('Error in add liquidity priceImpact query', {
       ...params,


### PR DESCRIPTION
also show the price impact for add liquidity when there is no wallet connected

![image](https://github.com/user-attachments/assets/f1cf7494-9770-449e-9a07-d21663aee15f)
