### PR TITLE
chore: handle BAL#402 (paused) error

### DIFF
--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -2,7 +2,7 @@
 
 import { AlertProps, Text } from '@chakra-ui/react'
 import { ErrorAlert } from './ErrorAlert'
-import { isUserRejectedError, isViemHttpFetchError } from '../../utils/error-filters'
+import { isPausedError, isUserRejectedError, isViemHttpFetchError } from '../../utils/error-filters'
 import { ensureError } from '../../utils/errors'
 import { BalAlertLink } from '../alerts/BalAlertLink'
 
@@ -24,6 +24,17 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
           report the problem in{' '}
           <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if the issue
           persists.
+        </Text>
+      </ErrorAlert>
+    )
+  }
+  if (isPausedError(_error)) {
+    return (
+      <ErrorAlert title={customErrorName} {...rest}>
+        <Text variant="secondary" color="black">
+          The pool or one of the pool tokens is paused. Check{' '}
+          <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> for more
+          information.
         </Text>
       </ErrorAlert>
     )

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -8,11 +8,16 @@ export function isUserRejectedError(error: Error): boolean {
 */
 export function isViemHttpFetchError(error?: Error | null): boolean {
   if (!error) return false
-  if (
-    error.message.startsWith('HTTP request failed.') &&
-    error.message.includes('Failed to fetch')
-  ) {
-    return true
-  }
-  return false
+  return (
+    error.message.startsWith('HTTP request failed.') && error.message.includes('Failed to fetch')
+  )
+}
+
+export function isPausedError(error?: Error | null): boolean {
+  if (!error) return false
+  return isPausedErrorMessage(error.message)
+}
+
+export function isPausedErrorMessage(errorMessage: string): boolean {
+  return errorMessage.includes('reverted with the following reason:\nBAL#402\n')
 }

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -6,7 +6,7 @@ import {
   Exception as SentryException,
 } from '@sentry/types'
 import { SentryError, ensureError } from './errors'
-import { isUserRejectedError } from './error-filters'
+import { isPausedErrorMessage, isUserRejectedError } from './error-filters'
 import {
   AddLiquidityParams,
   stringifyHumanAmountsIn,
@@ -331,6 +331,8 @@ export function shouldIgnore(message: string, stackTrace = ''): boolean {
   if (message.startsWith('The source') && message.includes('has not been authorized yet')) {
     return true
   }
+
+  if (isPausedErrorMessage(message)) return true
 
   return false
 }


### PR DESCRIPTION
Ignores sentry error and shows custom error message when catching a `paused` error.

Can be tested in pool `pools/ethereum/v2/0xdb1f2e1655477d08fb0992f82eede0053b8cd3820000000000000000000006ae/add-liquidity`

**Before**: 
<img width="473" alt="before" src="https://github.com/user-attachments/assets/3161a6c0-9b3a-401d-bf51-b198889c947e">

**After**:
<img width="541" alt="after" src="https://github.com/user-attachments/assets/c49afef6-a543-4aec-b518-f63a5cee3dca">



