### PR TITLE
Fix/gnosis alchemy rpc bug

### DIFF
--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -48,7 +48,7 @@ export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Base]: getPrivateRpcUrl(GqlChain.Base),
   [GqlChain.Avalanche]: getPrivateRpcUrl(GqlChain.Avalanche),
   [GqlChain.Fantom]: getPrivateRpcUrl(GqlChain.Fantom),
-  [GqlChain.Gnosis]: getPrivateRpcUrl(GqlChain.Gnosis),
+  [GqlChain.Gnosis]: 'https://rpc.gnosischain.com', // Temporary fix until we fix an alchemy rpc url issue (Reverted incorrect sender)
   [GqlChain.Optimism]: getPrivateRpcUrl(GqlChain.Optimism),
   [GqlChain.Polygon]: getPrivateRpcUrl(GqlChain.Polygon),
   [GqlChain.Zkevm]: getPrivateRpcUrl(GqlChain.Zkevm),


### PR DESCRIPTION
Use the public gnosis RPC url until we fix the root cause of the alchemy private rpc failing in Nested pool add/remove simulation requests.