### PR TITLE
fix: use DRPC private url in gnosis

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,5 +11,6 @@ PRIVATE_CURRENCYAPI_KEY=xxx
 
 # For integration tests and rpc proxy routes (optional)
 NEXT_PRIVATE_ALCHEMY_KEY=xxx
+NEXT_PRIVATE_DRPC_KEY=xxx
 
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,7 @@ env:
   NEXT_PUBLIC_BALANCER_API_URL: https://api-v3.balancer.fi/graphql
   NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
   NEXT_PRIVATE_ALCHEMY_KEY: ${{ secrets.PRIVATE_ALCHEMY_KEY }}
+  NEXT_PRIVATE_DRPC_KEY: ${{ secrets.PRIVATE_DRPC_KEY }}
 
 jobs:
   Build:

--- a/app/api/rpc/[chain]/route.ts
+++ b/app/api/rpc/[chain]/route.ts
@@ -7,6 +7,7 @@ type Params = {
 }
 
 const ALCHEMY_KEY = process.env.NEXT_PRIVATE_ALCHEMY_KEY || ''
+const DRPC_KEY = process.env.NEXT_PRIVATE_DRPC_KEY || ''
 
 const chainToRpcMap: Record<GqlChain, string | undefined> = {
   [GqlChain.Mainnet]: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
@@ -18,7 +19,7 @@ const chainToRpcMap: Record<GqlChain, string | undefined> = {
   [GqlChain.Fantom]: `https://fantom-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
   [GqlChain.Sepolia]: `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`,
   [GqlChain.Fraxtal]: `https://frax-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
-  [GqlChain.Gnosis]: `https://gnosis-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
+  [GqlChain.Gnosis]: `https://lb.drpc.org/ogrpc?network=gnosis&dkey=${DRPC_KEY}`,
   [GqlChain.Mode]: undefined,
   [GqlChain.Zkevm]: `https://polygonzkevm-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
 }
@@ -36,6 +37,11 @@ function getRpcUrl(chain: string) {
 export async function POST(request: Request, { params: { chain } }: Params) {
   if (!ALCHEMY_KEY) {
     return new Response(JSON.stringify({ error: 'NEXT_PRIVATE_ALCHEMY_KEY is missing' }), {
+      status: 500,
+    })
+  }
+  if (!DRPC_KEY) {
+    return new Response(JSON.stringify({ error: 'NEXT_PRIVATE_DRPC_KEY is missing' }), {
       status: 500,
     })
   }

--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -40,9 +40,8 @@ export const rpcFallbacks: Record<GqlChain, string | undefined> = {
 }
 
 const baseUrl = getBaseUrl()
-const getPrivateRpcUrl = (chain: GqlChain) => {
-  return `${baseUrl}/api/rpc/${chain}`
-}
+const getPrivateRpcUrl = (chain: GqlChain) => `${baseUrl}/api/rpc/${chain}`
+
 export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Mainnet]: getPrivateRpcUrl(GqlChain.Mainnet),
   [GqlChain.Arbitrum]: getPrivateRpcUrl(GqlChain.Arbitrum),

--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -40,15 +40,16 @@ export const rpcFallbacks: Record<GqlChain, string | undefined> = {
 }
 
 const baseUrl = getBaseUrl()
-const getPrivateRpcUrl = (chain: GqlChain) => `${baseUrl}/api/rpc/${chain}`
-
+const getPrivateRpcUrl = (chain: GqlChain) => {
+  return `${baseUrl}/api/rpc/${chain}`
+}
 export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Mainnet]: getPrivateRpcUrl(GqlChain.Mainnet),
   [GqlChain.Arbitrum]: getPrivateRpcUrl(GqlChain.Arbitrum),
   [GqlChain.Base]: getPrivateRpcUrl(GqlChain.Base),
   [GqlChain.Avalanche]: getPrivateRpcUrl(GqlChain.Avalanche),
   [GqlChain.Fantom]: getPrivateRpcUrl(GqlChain.Fantom),
-  [GqlChain.Gnosis]: 'https://rpc.gnosischain.com', // Temporary fix until we fix an alchemy rpc url issue (Reverted incorrect sender)
+  [GqlChain.Gnosis]: getPrivateRpcUrl(GqlChain.Gnosis),
   [GqlChain.Optimism]: getPrivateRpcUrl(GqlChain.Optimism),
   [GqlChain.Polygon]: getPrivateRpcUrl(GqlChain.Polygon),
   [GqlChain.Zkevm]: getPrivateRpcUrl(GqlChain.Zkevm),


### PR DESCRIPTION
You can test that nested add/remove simulation now works in gnosis pools:

https://frontend-v3-git-fix-gnosisdrpc-balancer.vercel.app/pools/gnosis/v2/0x66888e4f35063ad8bb11506a6fde5024fb4f1db0000100000000000000000053/add-liquidity