### PR TITLE
fix: maximize liquidity in sepolia

### DIFF
--- a/lib/modules/pool/actions/add-liquidity/form/useMaximumInputs.tsx
+++ b/lib/modules/pool/actions/add-liquidity/form/useMaximumInputs.tsx
@@ -23,10 +23,11 @@ export function useMaximumInputs() {
 
   // Depending on if the user is using WETH or ETH, we need to filter out the
   // native asset or wrapped native asset.
-  const nativeAssetFilter = (balance: TokenAmount) =>
-    wethIsEth
-      ? wNativeAsset && balance.address !== wNativeAsset.address
-      : nativeAsset && balance.address !== nativeAsset.address
+  const nativeAssetFilter = (balance: TokenAmount) => {
+    return wethIsEth
+      ? balance.address !== wNativeAsset?.address
+      : balance.address !== nativeAsset?.address
+  }
 
   const filteredBalances = useMemo(() => {
     return balances.filter(nativeAssetFilter)


### PR DESCRIPTION
The API is not currently not returning `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`  native tokens for sepolia: 
```
query {
  tokenGetTokens(chains: [SEPOLIA]) {
    address
  }
}

That breaks maximize feature in sepolia.

```

**Before**: 

![before](https://github.com/user-attachments/assets/6dab3d39-ab1f-4b39-b973-bc004cf5f722)

**After**: 

![after](https://github.com/user-attachments/assets/3d64f9d1-af1e-40b3-beb1-1cab56ae9c86)

