### PR TITLE
fix: setup private RPC urls for fraxtal and mode

### DIFF
--- a/lib/modules/web3/ChainConfig.tsx
+++ b/lib/modules/web3/ChainConfig.tsx
@@ -53,8 +53,8 @@ export const rpcOverrides: Record<GqlChain, string | undefined> = {
   [GqlChain.Polygon]: getPrivateRpcUrl(GqlChain.Polygon),
   [GqlChain.Zkevm]: getPrivateRpcUrl(GqlChain.Zkevm),
   [GqlChain.Sepolia]: getPrivateRpcUrl(GqlChain.Sepolia),
-  [GqlChain.Mode]: undefined,
-  [GqlChain.Fraxtal]: undefined,
+  [GqlChain.Mode]: getPrivateRpcUrl(GqlChain.Mode),
+  [GqlChain.Fraxtal]: getPrivateRpcUrl(GqlChain.Fraxtal),
 }
 
 const customMainnet = { iconUrl: '/images/chains/MAINNET.svg', ...mainnet }

--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -2,7 +2,12 @@
 
 import { AlertProps, Text } from '@chakra-ui/react'
 import { ErrorAlert } from './ErrorAlert'
-import { isPausedError, isUserRejectedError, isViemHttpFetchError } from '../../utils/error-filters'
+import {
+  isPausedError,
+  isTooManyRequestsError,
+  isUserRejectedError,
+  isViemHttpFetchError,
+} from '../../utils/error-filters'
 import { ensureError } from '../../utils/errors'
 import { BalAlertLink } from '../alerts/BalAlertLink'
 
@@ -35,6 +40,17 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
           The pool or one of the pool tokens is paused. Check{' '}
           <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> for more
           information.
+        </Text>
+      </ErrorAlert>
+    )
+  }
+  if (isTooManyRequestsError(_error)) {
+    return (
+      <ErrorAlert title={customErrorName} {...rest}>
+        <Text variant="secondary" color="black">
+          Too many RPC requests. Please try again in some minutes. You can report the problem in{' '}
+          <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if the issue
+          persists.
         </Text>
       </ErrorAlert>
     )

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -13,6 +13,19 @@ export function isViemHttpFetchError(error?: Error | null): boolean {
   )
 }
 
+/*
+  Detects 429 Too Many Requests errors thrown by wagmi/viem
+  We should not have many of them as we are using a private RPC provider but they still could happen when:
+  - the provider's rate limiting is not working as expected
+  - the provider is down and we are using a public fallback
+  - others
+*/
+export function isTooManyRequestsError(error?: Error | null): boolean {
+  console.log(error?.message)
+  if (!error) return false
+  return error.message.startsWith('HTTP request failed.') && error.message.includes('Status: 429')
+}
+
 export function isPausedError(error?: Error | null): boolean {
   if (!error) return false
   return isPausedErrorMessage(error.message)


### PR DESCRIPTION
We were having problems with Alchemy that should be fixed with dRPC.

Also adds a custom error message when 429 is detected (it should be a rare one):

<img width="632" alt="429Error" src="https://github.com/user-attachments/assets/431820d8-917e-42b6-9c42-42b894611b98">



