### PR TITLE
chore: add not enough gas error to generic error

### DIFF
--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -60,9 +60,9 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
     return (
       <ErrorAlert title={customErrorName} {...rest}>
         <Text variant="secondary" color="black">
-          It looks like you don&apos;t have enough gas for this transaction. You can report the
-          problem in <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if
-          the issue persists.
+          It looks like you don&apos;t have enough gas to complete this transaction. If you believe
+          this is a mistake, please report it in{' '}
+          <BalAlertLink href="https://discord.balancer.fi/">our discord.</BalAlertLink>
         </Text>
       </ErrorAlert>
     )

--- a/lib/shared/components/errors/GenericError.tsx
+++ b/lib/shared/components/errors/GenericError.tsx
@@ -3,6 +3,7 @@
 import { AlertProps, Text } from '@chakra-ui/react'
 import { ErrorAlert } from './ErrorAlert'
 import {
+  isNotEnoughGasError,
   isPausedError,
   isTooManyRequestsError,
   isUserRejectedError,
@@ -51,6 +52,17 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
           Too many RPC requests. Please try again in some minutes. You can report the problem in{' '}
           <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if the issue
           persists.
+        </Text>
+      </ErrorAlert>
+    )
+  }
+  if (isNotEnoughGasError(_error)) {
+    return (
+      <ErrorAlert title={customErrorName} {...rest}>
+        <Text variant="secondary" color="black">
+          It looks like you don&apos;t have enough gas for this transaction. You can report the
+          problem in <BalAlertLink href="https://discord.balancer.fi/">our discord</BalAlertLink> if
+          the issue persists.
         </Text>
       </ErrorAlert>
     )

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -26,6 +26,11 @@ export function isTooManyRequestsError(error?: Error | null): boolean {
   return error.message.startsWith('HTTP request failed.') && error.message.includes('Status: 429')
 }
 
+export function isNotEnoughGasError(error?: Error | null): boolean {
+  if (!error) return false
+  return error.message.startsWith('Execution reverted with reason: TRANSFER_FROM_FAILED.')
+}
+
 export function isPausedError(error?: Error | null): boolean {
   if (!error) return false
   return isPausedErrorMessage(error.message)

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -21,14 +21,15 @@ export function isViemHttpFetchError(error?: Error | null): boolean {
   - others
 */
 export function isTooManyRequestsError(error?: Error | null): boolean {
-  console.log(error?.message)
   if (!error) return false
   return error.message.startsWith('HTTP request failed.') && error.message.includes('Status: 429')
 }
 
 export function isNotEnoughGasError(error?: Error | null): boolean {
   if (!error) return false
-  return error.message.startsWith('Execution reverted with reason: TRANSFER_FROM_FAILED.')
+  return error.message.startsWith(
+    'The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.'
+  )
 }
 
 export function isPausedError(error?: Error | null): boolean {

--- a/lib/shared/utils/error-filters.ts
+++ b/lib/shared/utils/error-filters.ts
@@ -27,7 +27,11 @@ export function isTooManyRequestsError(error?: Error | null): boolean {
 
 export function isNotEnoughGasError(error?: Error | null): boolean {
   if (!error) return false
-  return error.message.startsWith(
+  return isNotEnoughGasErrorMessage(error.message)
+}
+
+export function isNotEnoughGasErrorMessage(errorMessage: string): boolean {
+  return errorMessage.startsWith(
     'The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.'
   )
 }

--- a/lib/shared/utils/query-errors.ts
+++ b/lib/shared/utils/query-errors.ts
@@ -6,7 +6,11 @@ import {
   Exception as SentryException,
 } from '@sentry/types'
 import { SentryError, ensureError } from './errors'
-import { isPausedErrorMessage, isUserRejectedError } from './error-filters'
+import {
+  isNotEnoughGasErrorMessage,
+  isPausedErrorMessage,
+  isUserRejectedError,
+} from './error-filters'
 import {
   AddLiquidityParams,
   stringifyHumanAmountsIn,
@@ -244,6 +248,8 @@ export function shouldIgnoreException(sentryException: SentryException) {
 
 export function shouldIgnore(message: string, stackTrace = ''): boolean {
   if (isUserRejectedError(new Error(message))) return true
+
+  if (isNotEnoughGasErrorMessage(message)) return true
 
   /*
     Thrown from useWalletClient() when loading a pool page from scratch.


### PR DESCRIPTION
Ignores error and displays specific alert when the user does not have enough gas to complete the transaction:

<img width="773" alt="notEnoughGasError" src="https://github.com/user-attachments/assets/a687a6e4-4fa4-40d8-abc4-a1de37d9f55e">

