### PR TITLE
fix: exclude WETH when wethIsEth in permit2

### DIFF
--- a/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -19,7 +19,6 @@ import {
 } from '@balancer/sdk'
 import BigNumber from 'bignumber.js'
 import { Address, Hex, formatUnits, parseUnits } from 'viem'
-import { GetTokenFn } from '../../tokens/TokensProvider'
 import {
   isNativeAsset,
   isNativeOrWrappedNative,
@@ -36,7 +35,6 @@ import {
   isUnbalancedLiquidityDisabled,
   isV3Pool,
 } from '../pool.helpers'
-import { SdkQueryAddLiquidityOutput } from './add-liquidity/add-liquidity.types'
 
 // Null object used to avoid conditional checks during hook loading state
 const NullPool: Pool = {
@@ -320,22 +318,4 @@ export function hasNoLiquidity(pool: Pool): boolean {
 export function formatBuildCallParams<T>(buildCallParams: T, account: Address) {
   // sender and recipient must be defined only for v1 and v2 pools
   return { ...buildCallParams, sender: account, recipient: account }
-}
-
-export function getTokenSymbols(
-  getToken: GetTokenFn,
-  chain: GqlChain,
-  queryOutput?: SdkQueryAddLiquidityOutput
-) {
-  if (!queryOutput?.sdkQueryOutput) return []
-  const amountsIn = queryOutput.sdkQueryOutput.amountsIn
-  const tokenSymbols = amountsIn
-    ?.filter(a => a.amount > 0n)
-    .map(a => getToken(a.token.address, chain)?.symbol ?? 'Unknown')
-  return tokenSymbols
-}
-
-export function getTokenAddresses(queryOutput?: SdkQueryAddLiquidityOutput): Address[] | undefined {
-  if (!queryOutput?.sdkQueryOutput) return undefined
-  return queryOutput.sdkQueryOutput.amountsIn.map(t => t.token.address)
 }

--- a/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
+++ b/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
@@ -54,6 +54,7 @@ export function useAddLiquiditySteps({
     slippagePercent: slippage,
     queryOutput: simulationQuery.data as SdkQueryAddLiquidityOutput,
     isPermit2,
+    wethIsEth: helpers.isNativeAssetIn(humanAmountsIn),
   })
 
   const isSignPermit2Loading = isPermit2 && !signPermit2Step

--- a/lib/modules/tokens/approvals/permit/useSignPermit.tsx
+++ b/lib/modules/tokens/approvals/permit/useSignPermit.tsx
@@ -100,6 +100,6 @@ function getButtonLabel(signPermitState: SignatureState, poolSymbol?: string) {
 }
 
 function getReadyLabel(poolSymbol?: string) {
-  if (!poolSymbol) return 'Sign aproval'
+  if (!poolSymbol) return 'Sign approval'
   return 'Sign approval: ' + poolSymbol
 }

--- a/lib/modules/tokens/approvals/permit2/permit2.helpers.ts
+++ b/lib/modules/tokens/approvals/permit2/permit2.helpers.ts
@@ -3,6 +3,9 @@ import { getNowTimestampInSecs } from '@/lib/shared/utils/time'
 import { AllowedAmountsByTokenAddress, ExpirationByTokenAddress } from './usePermit2Allowance'
 import { Address } from 'viem'
 import { TokenAmount } from '@balancer/sdk'
+import { getGqlChain } from '@/lib/config/app.config'
+import { filterWrappedNativeAsset } from '../../token.helpers'
+import { GetTokenFn } from '../../TokensProvider'
 
 export function hasValidPermit2(
   queryOutput?: SdkQueryAddLiquidityOutput,
@@ -20,4 +23,42 @@ export function hasValidPermit2(
     amountIn.amount === 0n || alreadyAllowed(amountIn)
   const isValid = !!queryOutput?.sdkQueryOutput.amountsIn.every(amountInValid)
   return isValid
+}
+
+type BasePermit2Params = {
+  queryOutput?: SdkQueryAddLiquidityOutput
+  wethIsEth: boolean
+}
+
+// Returns the symbols of the tokens that need to be approved for permit2
+export function getTokenSymbolsForPermit2({
+  getToken,
+  queryOutput,
+  wethIsEth,
+}: BasePermit2Params & { getToken: GetTokenFn }) {
+  if (!queryOutput) return []
+  const chain = getGqlChain(queryOutput.sdkQueryOutput.chainId)
+  const tokenSymbols = filterWrappedNativeAsset({
+    wethIsEth,
+    amountsIn: queryOutput.sdkQueryOutput.amountsIn,
+    chain,
+  })
+    .filter(a => a.amount > 0n)
+    .map(a => getToken(a.token.address, chain)?.symbol ?? 'Unknown')
+  return tokenSymbols
+}
+
+// Returns the token addresses that need to be approved for permit2
+export function getTokenAddressesForPermit2({
+  wethIsEth,
+  queryOutput,
+}: BasePermit2Params): Address[] | undefined {
+  if (!queryOutput?.sdkQueryOutput) return undefined
+  const chain = getGqlChain(queryOutput.sdkQueryOutput.chainId)
+  const result = filterWrappedNativeAsset({
+    wethIsEth,
+    chain,
+    amountsIn: queryOutput.sdkQueryOutput.amountsIn,
+  }).map(a => a.token.address)
+  return result
 }

--- a/lib/modules/tokens/approvals/permit2/useSignPermit2.tsx
+++ b/lib/modules/tokens/approvals/permit2/useSignPermit2.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { Pool } from '@/lib/modules/pool/PoolProvider'
-import { getTokenSymbols } from '@/lib/modules/pool/actions/LiquidityActionHelpers'
 import { SdkQueryAddLiquidityOutput } from '@/lib/modules/pool/actions/add-liquidity/add-liquidity.types'
 import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import {
@@ -17,6 +16,7 @@ import { HumanTokenAmountWithAddress } from '../../token.types'
 import { usePermit2Signature } from './Permit2SignatureProvider'
 import { signPermit2Add } from './signPermit2Add'
 import { NoncesByTokenAddress } from './usePermit2Allowance'
+import { getTokenSymbolsForPermit2 } from './permit2.helpers'
 
 export type AddLiquidityPermit2Params = {
   humanAmountsIn: HumanTokenAmountWithAddress[]
@@ -25,13 +25,14 @@ export type AddLiquidityPermit2Params = {
   slippagePercent: string
   nonces?: NoncesByTokenAddress
   isPermit2: boolean
+  wethIsEth: boolean
 }
 export function useSignPermit2({
-  pool,
   humanAmountsIn,
   queryOutput,
   slippagePercent,
   nonces,
+  wethIsEth,
 }: AddLiquidityPermit2Params) {
   const toast = useToast()
   const { userAddress } = useUserAccount()
@@ -66,6 +67,7 @@ export function useSignPermit2({
       const signature = await signPermit2Add({
         pool,
         humanAmountsIn,
+        wethIsEth,
         sdkClient,
         permit2Input: {
           account: userAddress,
@@ -102,7 +104,7 @@ export function useSignPermit2({
     signPermit2State,
     buttonLabel: getButtonLabel(
       signPermit2State,
-      getTokenSymbols(getToken, pool.chain, queryOutput)
+      getTokenSymbolsForPermit2({ getToken, queryOutput, wethIsEth })
     ),
     isLoading: isSignatureLoading(signPermit2State) || !queryOutput,
     isDisabled: isSignatureDisabled(signPermit2State),

--- a/lib/modules/tokens/token.helpers.ts
+++ b/lib/modules/tokens/token.helpers.ts
@@ -8,7 +8,7 @@ import { GqlChain } from '@/lib/shared/services/api/generated/graphql'
 import { includesAddress, isSameAddress } from '@/lib/shared/utils/addresses'
 import { Address } from 'viem'
 import { HumanTokenAmountWithAddress, TokenBase } from './token.types'
-import { InputAmount } from '@balancer/sdk'
+import { InputAmount, TokenAmount } from '@balancer/sdk'
 import { Pool } from '../pool/PoolProvider'
 import { getVaultConfig, isCowAmmPool, isV3Pool } from '../pool/pool.helpers'
 
@@ -143,4 +143,20 @@ export function getSpenderForAddLiquidity(pool: Pool): Address {
   }
   const { vaultAddress } = getVaultConfig(pool)
   return vaultAddress
+}
+
+// Excludes wrapped native asset from amountsIn when wethIsEth
+export function filterWrappedNativeAsset({
+  amountsIn,
+  wethIsEth,
+  chain,
+}: {
+  amountsIn: TokenAmount[]
+  wethIsEth: boolean
+  chain: GqlChain
+}): TokenAmount[] {
+  if (!wethIsEth) return amountsIn
+  return amountsIn.filter(a => {
+    return !isWrappedNativeAsset(a.token.address, chain)
+  })
 }

--- a/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
+++ b/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
@@ -6,9 +6,13 @@ import { useUserAccount } from '@/lib/modules/web3/UserAccountProvider'
 import { BalAlert } from '@/lib/shared/components/alerts/BalAlert'
 import { Button, VStack } from '@chakra-ui/react'
 import { useMemo } from 'react'
-import { getTokenAddresses, getTokenSymbols } from '../../pool/actions/LiquidityActionHelpers'
+
 import { useTokens } from '../../tokens/TokensProvider'
-import { hasValidPermit2 } from '../../tokens/approvals/permit2/permit2.helpers'
+import {
+  getTokenAddressesForPermit2,
+  getTokenSymbolsForPermit2,
+  hasValidPermit2,
+} from '../../tokens/approvals/permit2/permit2.helpers'
 import { usePermit2Allowance } from '../../tokens/approvals/permit2/usePermit2Allowance'
 import {
   AddLiquidityPermit2Params,
@@ -28,7 +32,10 @@ export function useSignPermit2Step(params: AddLiquidityPermit2Params): Transacti
 
   const { isLoadingPermit2Allowances, nonces, expirations, allowedAmounts } = usePermit2Allowance({
     chainId: getChainId(params.pool.chain),
-    tokenAddresses: getTokenAddresses(params.queryOutput),
+    tokenAddresses: getTokenAddressesForPermit2({
+      queryOutput: params.queryOutput,
+      wethIsEth: params.wethIsEth,
+    }),
     owner: userAddress,
     enabled: params.isPermit2,
   })
@@ -78,7 +85,11 @@ export function useSignPermit2Step(params: AddLiquidityPermit2Params): Transacti
 
   const details: StepDetails = {
     gasless: true,
-    batchApprovalTokens: getTokenSymbols(getToken, params.pool.chain, params.queryOutput),
+    batchApprovalTokens: getTokenSymbolsForPermit2({
+      getToken,
+      queryOutput: params.queryOutput,
+      wethIsEth: params.wethIsEth,
+    }),
   }
 
   return useMemo(

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -2,6 +2,7 @@ import { startProxy } from '@viem/anvil'
 
 import { ANVIL_NETWORKS, getForkUrl } from './anvil-setup'
 import { testChains } from './testWagmiConfig'
+import { sleep } from '@/lib/shared/utils/sleep'
 
 export async function setup() {
   const promises = []
@@ -25,6 +26,8 @@ export async function setup() {
     )
   }
   const results = await Promise.all(promises)
+  // Wait for the proxy to start
+  await sleep(2000)
 
   return () => {
     for (const shutdown of results) {


### PR DESCRIPTION
Avoid `WETH` Permit2 signature when the user is using `ETH` as token in (`wethIsEth`).
Applies for any native asset. 

<img width="856" alt="Screenshot 2024-10-10 at 19 28 18" src="https://github.com/user-attachments/assets/a97fd7bb-3a38-4de8-8a21-f13651fcc542">
